### PR TITLE
Allow granting "Reader" role when single roles is configured.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0.7 (unreleased)
 ------------------
 
+- Allow granting "Reader" role when single roles is configured.
+  [jone]
+
 - Possibility to configure if only one or multiple roles can be passed
   on invite form.
   [mathias.leimgruber]
@@ -48,11 +51,6 @@ Changelog
 - Some german translations.
   [mathias.leimgruber]
 
-
-1.0.3 (2012-10-16)
-------------------
-
-- Nothing changed yet.
 
 
 1.0.2 (2012-10-10)

--- a/ftw/participation/browser/invite.py
+++ b/ftw/participation/browser/invite.py
@@ -51,8 +51,6 @@ class IInviteSchema(Interface):
 
     roles = schema.List(
         title=_(u'label_roles', default=u'Roles'),
-        description=_(u'help_roles',
-                      default=u'Select Role(s) for the choosen users'),
         value_type=schema.Choice(
             vocabulary=u'ftw.participation.roles'),
         required=False)

--- a/ftw/participation/locales/de/LC_MESSAGES/ftw.participation.po
+++ b/ftw/participation/locales/de/LC_MESSAGES/ftw.participation.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-07-25 16:17+0000\n"
+"POT-Creation-Date: 2013-07-31 12:57+0000\n"
 "PO-Revision-Date: 2010-09-08 18:05+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -10,6 +10,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
+"Domain: DOMAIN\n"
 
 #: ./ftw/participation/browser/invitations.pt:62
 msgid "Accept"
@@ -152,11 +153,6 @@ msgstr "Dieser Kommentar wird ins Einladungs-E-Mail eingefügt."
 #: ./ftw/participation/quota.py:37
 msgid "help_participation_quota_limit"
 msgstr "Mit hilfe des Quota limits können Sie die maximale Teilnehmerzahl definieren"
-
-#. Default: "Select Role(s) for the choosen users"
-#: ./ftw/participation/browser/invite.py:53
-msgid "help_roles"
-msgstr "Sie können den eingeladenen Personen zusätzliche Rechte nebst dem Lese-Recht zuteilen"
 
 #. Default: "Select users to invite."
 #: ./ftw/participation/browser/invite.py:39

--- a/ftw/participation/locales/ftw.participation.pot
+++ b/ftw/participation/locales/ftw.participation.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-07-25 16:17+0000\n"
+"POT-Creation-Date: 2013-07-31 12:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -157,11 +157,6 @@ msgstr ""
 
 #: ./ftw/participation/quota.py:37
 msgid "help_participation_quota_limit"
-msgstr ""
-
-#. Default: "Select Role(s) for the choosen users"
-#: ./ftw/participation/browser/invite.py:53
-msgid "help_roles"
 msgstr ""
 
 #. Default: "Select users to invite."

--- a/ftw/participation/vocabularies.py
+++ b/ftw/participation/vocabularies.py
@@ -1,9 +1,12 @@
+from Acquisition import aq_inner
+from Products.CMFCore.utils import getToolByName
+from ftw.participation.interfaces import IParticipationRegistry
+from plone.app.workflow.interfaces import ISharingPageRole
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtilitiesFor
+from zope.component import getUtility
 from zope.interface import implements
 from zope.schema.interfaces import IVocabularyFactory
-from Acquisition import aq_inner
-from plone.app.workflow.interfaces import ISharingPageRole
-from Products.CMFCore.utils import getToolByName
-from zope.component import getUtilitiesFor
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
 
@@ -13,8 +16,17 @@ class LocalRolesForDisplay(object):
 
     implements(IVocabularyFactory)
 
-    def __call__(self, context, role_filter=['Reader', 'Reviewer', ]):
+    def __call__(self, context, role_filter=None, filter_reader_role=True):
         """Get a list of roles, similar like @@sharing"""
+
+        if role_filter is None:
+            role_filter = ['Reviewer', ]
+
+        registry = getUtility(IRegistry)
+        config = registry.forInterface(IParticipationRegistry)
+        if filter_reader_role and config.allow_multiple_roles:
+            role_filter = role_filter + ['Reader']
+
         context = aq_inner(context)
         portal_membership = getToolByName(context, 'portal_membership')
 


### PR DESCRIPTION
- when `allow_multiple_roles` is false, make `Reader` role selectable by default
- remove roles field description since it is not accurate anymore

/cc @maethu 
