### PR TITLE
Set roles field on invitation form to required if multiple roles is disabled

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0.7 (unreleased)
 ------------------
 
+- Set roles field on invitation form to required if multiple roles is disabled.
+  [mathias.leimgruber]
+
 - Allow granting "Reader" role when single roles is configured.
   [jone]
 

--- a/ftw/participation/browser/invite.py
+++ b/ftw/participation/browser/invite.py
@@ -149,6 +149,23 @@ WidgetsValidatorDiscriminators(NumberOfAdressesAndUsersValidator,
 provideAdapter(NumberOfAdressesAndUsersValidator)
 
 
+class RolesValidator(SimpleFieldValidator):
+    """Validator for validating the e-mail addresses field
+    """
+
+    def validate(self, roles):
+        registry = getUtility(IRegistry)
+        config = registry.forInterface(IParticipationRegistry)
+
+        if not config.allow_multiple_roles and not roles:
+            msg = _(u'error_no_roles', default=u'Please select a role')
+            raise Invalid(msg)
+
+WidgetValidatorDiscriminators(RolesValidator,
+                               field=IInviteSchema['roles'])
+provideAdapter(RolesValidator)
+
+
 class InviteForm(Form):
     label = _(u'label_invite_participants', default=u'Invite Participants')
 
@@ -184,6 +201,9 @@ class InviteForm(Form):
             # disable users field
             del self.widgets['users']
             self.widgets['addresses'].required = True
+
+        if not config.allow_multiple_roles:
+            self.widgets['roles'].required = True
 
     def updateActions(self):
         super(InviteForm, self).updateActions()

--- a/ftw/participation/locales/de/LC_MESSAGES/ftw.participation.po
+++ b/ftw/participation/locales/de/LC_MESSAGES/ftw.participation.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-07-31 12:57+0000\n"
+"POT-Creation-Date: 2013-08-02 15:45+0000\n"
 "PO-Revision-Date: 2010-09-08 18:05+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -10,7 +10,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: DOMAIN\n"
 
 #: ./ftw/participation/browser/invitations.pt:62
 msgid "Accept"
@@ -20,7 +19,7 @@ msgstr "Akzeptieren"
 msgid "Changes saved."
 msgstr "Änderungen wurden Gespeichert"
 
-#: ./ftw/participation/browser/invite.py:125
+#: ./ftw/participation/browser/invite.py:124
 msgid "Enter at least one e-mail address."
 msgstr "Geben Sie mindestens eine E-Mail Adresse an."
 
@@ -44,11 +43,11 @@ msgstr "ablehnen"
 msgid "Retract"
 msgstr "Widerrufen"
 
-#: ./ftw/participation/browser/invite.py:122
+#: ./ftw/participation/browser/invite.py:121
 msgid "Select at least one user or enter at least one e-mail address"
 msgstr "Wählen Sie mindestens eine Person aus oder geben Sie mindestens eine E-Mail Adresse an."
 
-#: ./ftw/participation/browser/invite.py:127
+#: ./ftw/participation/browser/invite.py:126
 msgid "Select at least one user."
 msgstr "Wählen Sie mindestens ein Benutzer aus."
 
@@ -69,23 +68,23 @@ msgid "accepted_mail_text"
 msgstr "Ihre Einladung um an ${context_title} teilzunehmen wurde vom User ${invited_name} akzeptiert"
 
 #. Default: "Cancel"
-#: ./ftw/participation/browser/invite.py:229
-#: ./ftw/participation/browser/participants.pt:75
+#: ./ftw/participation/browser/invite.py:258
+#: ./ftw/participation/browser/participants.pt:74
 msgid "button_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Delete Participants"
-#: ./ftw/participation/browser/participants.pt:71
+#: ./ftw/participation/browser/participants.pt:70
 msgid "button_delete_participants"
 msgstr "Personen löschen"
 
 #. Default: "Invite"
-#: ./ftw/participation/browser/invite.py:183
+#: ./ftw/participation/browser/invite.py:212
 msgid "button_invite"
 msgstr "Einladen"
 
 #. Default: "At least one of the defined addresses are not valid."
-#: ./ftw/participation/browser/invite.py:99
+#: ./ftw/participation/browser/invite.py:98
 msgid "error_invalid_addresses"
 msgstr "Mindestens eine der eingegebenen Adressen ist ungültig"
 
@@ -100,13 +99,18 @@ msgstr "Die Einladung konnte nicht gefunden werden"
 msgid "error_inviter_email_missing"
 msgstr "Die einladende Person konnte nicht benachrichtigt werden: Er hat keine E-Mail-Adresse definiert"
 
+#. Default: "Please select a role"
+#: ./ftw/participation/browser/invite.py:161
+msgid "error_no_roles"
+msgstr "Bitte wählen Sie eine Berechtigung aus."
+
 #. Default: "The participation quota is reached, you cannot add any further participants."
-#: ./ftw/participation/browser/invite.py:135
+#: ./ftw/participation/browser/invite.py:134
 msgid "error_participation_quota_reached"
 msgstr "Die Maximale Teilnehmerzahl ist erreicht, Sie können keine Teilnehmer mehr hinzufügen"
 
 #. Default: "You cannot invite so many participants any more. Can only add ${num} more participants."
-#: ./ftw/participation/browser/invite.py:139
+#: ./ftw/participation/browser/invite.py:138
 msgid "error_too_many_participants"
 msgstr "Sie können nicht mehr so viele Teilnehmer einladen. Sie können maximal ${num} Einladungen versenden."
 
@@ -131,7 +135,7 @@ msgid "headline_sent_invitations"
 msgstr "Versendete Einladungen"
 
 #. Default: "Enter one e-mail address per line"
-#: ./ftw/participation/browser/invite.py:47
+#: ./ftw/participation/browser/invite.py:48
 msgid "help_addresses"
 msgstr "Um neue Personen einzuladen, geben Sie eine E-Mail Adresse pro Zeile ein"
 
@@ -146,7 +150,7 @@ msgid "help_allow_invite_users"
 msgstr "Bestehende Benutzer können durchsucht und eingeladen werden."
 
 #. Default: "Enter a comment which will be contained in the invitaiton E-Mail"
-#: ./ftw/participation/browser/invite.py:61
+#: ./ftw/participation/browser/invite.py:60
 msgid "help_comment"
 msgstr "Dieser Kommentar wird ins Einladungs-E-Mail eingefügt."
 
@@ -155,7 +159,7 @@ msgid "help_participation_quota_limit"
 msgstr "Mit hilfe des Quota limits können Sie die maximale Teilnehmerzahl definieren"
 
 #. Default: "Select users to invite."
-#: ./ftw/participation/browser/invite.py:39
+#: ./ftw/participation/browser/invite.py:40
 msgid "help_users"
 msgstr "Wählen Sie einen oder mehrere Personen aus. Sie können nach der E-Mail Adresse oder Vor bzw. Nachnamen suchen"
 
@@ -175,7 +179,7 @@ msgid "info_invitation_retracted"
 msgstr "Sie haben die Einladung widerrufen"
 
 #. Default: "The invitation mails were sent to ${emails}."
-#: ./ftw/participation/browser/invite.py:223
+#: ./ftw/participation/browser/invite.py:252
 msgid "info_invitations_sent"
 msgstr "Die Einladungen wurden per E-Mail an ${emails} versendet."
 
@@ -219,12 +223,12 @@ msgid "invitation_mail_message"
 msgstr "Nachricht von ${inviter_name}:"
 
 #. Default: "Accepted"
-#: ./ftw/participation/browser/participants.pt:53
+#: ./ftw/participation/browser/participants.pt:52
 msgid "label_accepted"
 msgstr "Angenommen"
 
 #. Default: "E-Mail Addresses"
-#: ./ftw/participation/browser/invite.py:46
+#: ./ftw/participation/browser/invite.py:47
 msgid "label_addresses"
 msgstr "E-Mail Adressen"
 
@@ -239,24 +243,29 @@ msgid "label_allow_invite_users"
 msgstr "Existierende Benutzer beteiligen"
 
 #. Default: "Comment"
-#: ./ftw/participation/browser/invite.py:60
+#: ./ftw/participation/browser/invite.py:59
 msgid "label_comment"
 msgstr "Kommentar"
 
 #. Default: "Invite Participants"
-#: ./ftw/participation/browser/invite.py:154
+#: ./ftw/participation/browser/invite.py:170
 msgid "label_invite_participants"
 msgstr "Personen einladen"
 
 #. Default: "Invited by"
-#: ./ftw/participation/browser/participants.pt:35
+#: ./ftw/participation/browser/participants.pt:34
 msgid "label_invited_by"
 msgstr "Eingeladen von"
 
 #. Default: "Roles"
-#: ./ftw/participation/browser/participants.pt:34
+#: ./ftw/participation/browser/participants.pt:33
 msgid "label_local_roles"
 msgstr "Rollen"
+
+#. Default: "Allow to give multiple roles"
+#: ./ftw/participation/interfaces.py:33
+msgid "label_multiple_roles"
+msgstr ""
 
 #. Default: "Participation quota limit"
 #: ./ftw/participation/quota.py:35
@@ -264,27 +273,27 @@ msgid "label_participation_quota_limit"
 msgstr "Maximale Anzahl Teilnehmer"
 
 #. Default: "Pending"
-#: ./ftw/participation/browser/participants.pt:56
+#: ./ftw/participation/browser/participants.pt:55
 msgid "label_pending"
 msgstr "offen"
 
 #. Default: "Roles"
-#: ./ftw/participation/browser/invite.py:52
+#: ./ftw/participation/browser/invite.py:53
 msgid "label_roles"
 msgstr "Berechtigungen"
 
 #. Default: "State"
-#: ./ftw/participation/browser/participants.pt:36
+#: ./ftw/participation/browser/participants.pt:35
 msgid "label_state"
 msgstr "Status"
 
 #. Default: "User"
-#: ./ftw/participation/browser/participants.pt:33
+#: ./ftw/participation/browser/participants.pt:32
 msgid "label_user"
 msgstr "Benutzer"
 
 #. Default: "Users"
-#: ./ftw/participation/browser/invite.py:38
+#: ./ftw/participation/browser/invite.py:39
 msgid "label_users"
 msgstr "Benutzer"
 
@@ -294,7 +303,7 @@ msgid "link_accept_invitation"
 msgstr "Ja, ich möchte teilnehmen"
 
 #. Default: "Invite participants"
-#: ./ftw/participation/browser/participants.pt:64
+#: ./ftw/participation/browser/participants.pt:63
 msgid "link_invite_participants"
 msgstr "Personen einladen"
 
@@ -314,7 +323,7 @@ msgid "mail_invitation_rejected_subject"
 msgstr "Die Einladung um an ${title} teilzunehmen wurde von ${user} abgelehnt"
 
 #. Default: "Invitation for paticipating in ${title}"
-#: ./ftw/participation/browser/invite.py:296
+#: ./ftw/participation/browser/invite.py:325
 msgid "mail_invitation_subject"
 msgstr "Einladung zur Teilnahme an ${title}"
 
@@ -331,12 +340,12 @@ msgid "rejected_mail_text"
 msgstr "Ihre einladung an ${context_title} teilzunehmen wurde vom Benutzer ${invited_name} abgelehnt (${invited_email})."
 
 #. Default: "General informations about the people who participate on this project. You are also able to remove users from this project."
-#: ./ftw/participation/browser/participants.pt:22
+#: ./ftw/participation/browser/participants.pt:21
 msgid "text_infos_participants"
 msgstr "Stellen Sie Ihr Team für den aktuellen Teamraum zusammen. Die Tabelle zeigt alle involvierten Personen. Klicken sie auf \"Personen einladen\" um Ihr Team zu vergrössern."
 
 #. Default: "Use this form to invide new user"
-#: ./ftw/participation/browser/invite.py:156
+#: ./ftw/participation/browser/invite.py:172
 msgid "text_invite_new"
 msgstr "Mit diesem Formular können Sie neue Personen einladen. Nach dem Klicken auf \"Einladen\", werden an die ausgewählten Personen E-Mails mit den Einladungen versendet."
 

--- a/ftw/participation/locales/ftw.participation.pot
+++ b/ftw/participation/locales/ftw.participation.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-07-31 12:57+0000\n"
+"POT-Creation-Date: 2013-08-02 15:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,7 +25,7 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: ./ftw/participation/browser/invite.py:125
+#: ./ftw/participation/browser/invite.py:124
 msgid "Enter at least one e-mail address."
 msgstr ""
 
@@ -49,11 +49,11 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: ./ftw/participation/browser/invite.py:122
+#: ./ftw/participation/browser/invite.py:121
 msgid "Select at least one user or enter at least one e-mail address"
 msgstr ""
 
-#: ./ftw/participation/browser/invite.py:127
+#: ./ftw/participation/browser/invite.py:126
 msgid "Select at least one user."
 msgstr ""
 
@@ -74,23 +74,23 @@ msgid "accepted_mail_text"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./ftw/participation/browser/invite.py:229
-#: ./ftw/participation/browser/participants.pt:75
+#: ./ftw/participation/browser/invite.py:258
+#: ./ftw/participation/browser/participants.pt:74
 msgid "button_cancel"
 msgstr ""
 
 #. Default: "Delete Participants"
-#: ./ftw/participation/browser/participants.pt:71
+#: ./ftw/participation/browser/participants.pt:70
 msgid "button_delete_participants"
 msgstr ""
 
 #. Default: "Invite"
-#: ./ftw/participation/browser/invite.py:183
+#: ./ftw/participation/browser/invite.py:212
 msgid "button_invite"
 msgstr ""
 
 #. Default: "At least one of the defined addresses are not valid."
-#: ./ftw/participation/browser/invite.py:99
+#: ./ftw/participation/browser/invite.py:98
 msgid "error_invalid_addresses"
 msgstr ""
 
@@ -105,13 +105,18 @@ msgstr ""
 msgid "error_inviter_email_missing"
 msgstr ""
 
+#. Default: "Please select a role"
+#: ./ftw/participation/browser/invite.py:161
+msgid "error_no_roles"
+msgstr ""
+
 #. Default: "The participation quota is reached, you cannot add any further participants."
-#: ./ftw/participation/browser/invite.py:135
+#: ./ftw/participation/browser/invite.py:134
 msgid "error_participation_quota_reached"
 msgstr ""
 
 #. Default: "You cannot invite so many participants any more. Can only add ${num} more participants."
-#: ./ftw/participation/browser/invite.py:139
+#: ./ftw/participation/browser/invite.py:138
 msgid "error_too_many_participants"
 msgstr ""
 
@@ -136,7 +141,7 @@ msgid "headline_sent_invitations"
 msgstr ""
 
 #. Default: "Enter one e-mail address per line"
-#: ./ftw/participation/browser/invite.py:47
+#: ./ftw/participation/browser/invite.py:48
 msgid "help_addresses"
 msgstr ""
 
@@ -151,7 +156,7 @@ msgid "help_allow_invite_users"
 msgstr ""
 
 #. Default: "Enter a comment which will be contained in the invitaiton E-Mail"
-#: ./ftw/participation/browser/invite.py:61
+#: ./ftw/participation/browser/invite.py:60
 msgid "help_comment"
 msgstr ""
 
@@ -160,7 +165,7 @@ msgid "help_participation_quota_limit"
 msgstr ""
 
 #. Default: "Select users to invite."
-#: ./ftw/participation/browser/invite.py:39
+#: ./ftw/participation/browser/invite.py:40
 msgid "help_users"
 msgstr ""
 
@@ -180,7 +185,7 @@ msgid "info_invitation_retracted"
 msgstr ""
 
 #. Default: "The invitation mails were sent to ${emails}."
-#: ./ftw/participation/browser/invite.py:223
+#: ./ftw/participation/browser/invite.py:252
 msgid "info_invitations_sent"
 msgstr ""
 
@@ -224,12 +229,12 @@ msgid "invitation_mail_message"
 msgstr ""
 
 #. Default: "Accepted"
-#: ./ftw/participation/browser/participants.pt:53
+#: ./ftw/participation/browser/participants.pt:52
 msgid "label_accepted"
 msgstr ""
 
 #. Default: "E-Mail Addresses"
-#: ./ftw/participation/browser/invite.py:46
+#: ./ftw/participation/browser/invite.py:47
 msgid "label_addresses"
 msgstr ""
 
@@ -244,23 +249,28 @@ msgid "label_allow_invite_users"
 msgstr ""
 
 #. Default: "Comment"
-#: ./ftw/participation/browser/invite.py:60
+#: ./ftw/participation/browser/invite.py:59
 msgid "label_comment"
 msgstr ""
 
 #. Default: "Invite Participants"
-#: ./ftw/participation/browser/invite.py:154
+#: ./ftw/participation/browser/invite.py:170
 msgid "label_invite_participants"
 msgstr ""
 
 #. Default: "Invited by"
-#: ./ftw/participation/browser/participants.pt:35
+#: ./ftw/participation/browser/participants.pt:34
 msgid "label_invited_by"
 msgstr ""
 
 #. Default: "Roles"
-#: ./ftw/participation/browser/participants.pt:34
+#: ./ftw/participation/browser/participants.pt:33
 msgid "label_local_roles"
+msgstr ""
+
+#. Default: "Allow to give multiple roles"
+#: ./ftw/participation/interfaces.py:33
+msgid "label_multiple_roles"
 msgstr ""
 
 #. Default: "Participation quota limit"
@@ -269,27 +279,27 @@ msgid "label_participation_quota_limit"
 msgstr ""
 
 #. Default: "Pending"
-#: ./ftw/participation/browser/participants.pt:56
+#: ./ftw/participation/browser/participants.pt:55
 msgid "label_pending"
 msgstr ""
 
 #. Default: "Roles"
-#: ./ftw/participation/browser/invite.py:52
+#: ./ftw/participation/browser/invite.py:53
 msgid "label_roles"
 msgstr ""
 
 #. Default: "State"
-#: ./ftw/participation/browser/participants.pt:36
+#: ./ftw/participation/browser/participants.pt:35
 msgid "label_state"
 msgstr ""
 
 #. Default: "User"
-#: ./ftw/participation/browser/participants.pt:33
+#: ./ftw/participation/browser/participants.pt:32
 msgid "label_user"
 msgstr ""
 
 #. Default: "Users"
-#: ./ftw/participation/browser/invite.py:38
+#: ./ftw/participation/browser/invite.py:39
 msgid "label_users"
 msgstr ""
 
@@ -298,7 +308,7 @@ msgstr ""
 msgid "link_accept_invitation"
 msgstr ""
 
-#: ./ftw/participation/browser/participants.pt:64
+#: ./ftw/participation/browser/participants.pt:63
 msgid "link_invite_participants"
 msgstr ""
 
@@ -318,7 +328,7 @@ msgid "mail_invitation_rejected_subject"
 msgstr ""
 
 #. Default: "Invitation for paticipating in ${title}"
-#: ./ftw/participation/browser/invite.py:296
+#: ./ftw/participation/browser/invite.py:325
 msgid "mail_invitation_subject"
 msgstr ""
 
@@ -335,12 +345,12 @@ msgid "rejected_mail_text"
 msgstr ""
 
 #. Default: "General informations about the people who participate on this project. You are also able to remove users from this project."
-#: ./ftw/participation/browser/participants.pt:22
+#: ./ftw/participation/browser/participants.pt:21
 msgid "text_infos_participants"
 msgstr ""
 
 #. Default: "Use this form to invide new user"
-#: ./ftw/participation/browser/invite.py:156
+#: ./ftw/participation/browser/invite.py:172
 msgid "text_invite_new"
 msgstr ""
 


### PR DESCRIPTION
@jone 

I tried http://developer.plone.org/forms/z3c.form.html#making-widgets-required-conditionally
but it did no work in my case (don't know why)

My workaround is --> WidgetValidatorDiscriminators for the field roles
