### PR TITLE
encode mail correctly for outlook

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Encode Mailheaders correctly.
+  [tschanzt]
 
 
 1.2.0 (2014-02-03)

--- a/ftw/participation/browser/accept.py
+++ b/ftw/participation/browser/accept.py
@@ -77,10 +77,8 @@ class AcceptInvitation(BrowserView):
         properties = getUtility(IPropertiesTool)
         mtool = getToolByName(self.context, 'portal_membership')
         # prepare from address for header
-        from_str = properties.email_from_name
-        if isinstance(from_str, unicode):
-            from_str = from_str.encode('utf8')
-        from_str += ' <%s>' % properties.email_from_address
+        from_str = Header(properties.email_from_name, 'utf-8')
+        from_str.append('<%s>' % properties.email_from_address)
 
         # To
         to_member = mtool.getMemberById(self.invitation.inviter)
@@ -93,16 +91,16 @@ class AcceptInvitation(BrowserView):
         to_str = to_member.getProperty('fullname', to_member.getId())
         if isinstance(to_str, unicode):
             to_str = to_str.encode('utf8')
-        to_str += ' <%s>' % to_member.getProperty('email')
-        header_to = Header(to_str.decode('utf8'), 'windows-1252')
-
+        header_to = Header(to_str, 'utf-8')
+        header_to.append(u'<%s>' % to_member.getProperty(
+                'email').decode('utf-8'))
         # Subject
         subject = self.get_subject()
         if isinstance(subject, unicode):
             subject = subject.encode('utf8')
-        header_subject = Header(subject.decode('utf8'), 'windows-1252')
+        header_subject = Header(subject, 'utf8')
 
-        # Options for template
+        # Options for templated
         options = {
             'invitation': self.invitation,
             'inviter': to_member,
@@ -119,23 +117,21 @@ class AcceptInvitation(BrowserView):
         # make the mail
         msg = MIMEMultipart('alternative')
         msg['Subject'] = header_subject
-        #msg['From'] = header_from
-        msg['To'] = header_to
-
+        msg['From'] = str(from_str)
+        msg['To'] = str(header_to)
         # get the body views
         html_view = self.get_mail_body_html_view()
         text_view = self.get_mail_body_text_view()
 
         # render and emmbed body
-        text_body = text_view(**options).encode('windows-1252')
-        msg.attach(MIMEText(text_body, 'plain', 'windows-1252'))
-        html_body = html_view(**options).encode('windows-1252')
-        msg.attach(MIMEText(html_body, 'html', 'windows-1252'))
+        text_body = text_view(**options).encode('utf-8')
+        msg.attach(MIMEText(text_body, 'plain', 'utf-8'))
+        html_body = html_view(**options).encode('utf-8')
+        msg.attach(MIMEText(html_body, 'html', 'utf-8'))
 
         # send the email
         mh = getToolByName(self.context, 'MailHost')
-        mh.send(msg, mto=to_member.getProperty('email'),
-                mfrom=from_str.decode('utf8').encode('windows-1252'))
+        mh.send(msg)
 
     def get_mail_body_html_view(self):
         return self.context.unrestrictedTraverse(

--- a/ftw/participation/browser/invite.py
+++ b/ftw/participation/browser/invite.py
@@ -273,12 +273,12 @@ class InviteForm(Form):
         properties = getUtility(IPropertiesTool)
         # prepare from address for header
         header_from = Header(properties.email_from_name,
-                             'iso-8859-1')
+                             'utf-8')
         header_from.append(u'<%s>' % properties.email_from_address.
                            decode('utf-8'),
-                           'iso-8859-1')
+                           'utf-8')
         # get subject
-        header_subject = Header(unicode(self.get_subject()), 'iso-8859-1')
+        header_subject = Header(unicode(self.get_subject()), 'utf-8')
 
         # prepare comment
         pttool = getToolByName(self.context, 'portal_transforms')
@@ -303,7 +303,7 @@ class InviteForm(Form):
         # make the mail
         msg = MIMEMultipart('alternative')
         msg['Subject'] = header_subject
-        msg['From'] = header_from.encode('iso-8859-1')
+        msg['From'] = header_from
         msg['To'] = email
 
         # render and embedd html / text
@@ -313,7 +313,7 @@ class InviteForm(Form):
         msg.attach(MIMEText(html_body, 'html', 'utf-8'))
         # send the mail
         mh = getToolByName(self.context, 'MailHost')
-        mh.send(msg, mto=email)
+        mh.send(msg)
 
     def get_subject(self):
         """Returns the translated subject of the email.

--- a/ftw/participation/tests/test_accept.py
+++ b/ftw/participation/tests/test_accept.py
@@ -1,0 +1,56 @@
+from ftw.participation.tests.layer import FTW_PARTICIPATION_INTEGRATION_TESTING
+from unittest2 import TestCase
+from plone.app.testing import login, setRoles
+from ftw.participation.interfaces import IParticipationSupport
+from ftw.participation.interfaces import IParticipationBrowserLayer
+from ftw.participation.invitation import Invitation
+from zope.interface import alsoProvides
+from ftw.testing.mailing import Mailing
+from Products.CMFCore.utils import getToolByName
+from ftw.builder import Builder
+from ftw.builder import create
+import re
+
+
+class TestInvitationAcceptmail(TestCase):
+
+    layer = FTW_PARTICIPATION_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        alsoProvides(self.portal.REQUEST, IParticipationBrowserLayer)
+        self.portal_url = self.portal.portal_url()
+
+
+
+
+        create(Builder('user').named('Felix', 'Leiter').with_roles('Manager'))
+
+        create(Builder('user').named('James', 'Bond').with_roles('Manager'))
+
+        self.folder = create(Builder('folder'))
+
+        login(self.portal, 'felix.leiter')
+
+        alsoProvides(self.folder, IParticipationSupport)
+        Mailing(self.layer['portal']).set_up()
+
+    def tearDown(self):
+        Mailing(self.layer['portal']).tear_down()
+
+    def test_accept_mail(self):
+        invitation = Invitation(target=self.folder,
+                                email='felix@leiter.com',
+                                inviter='james.bond',
+                                roles=['Reader'])
+
+        view = self.portal.restrictedTraverse('accept_invitation')
+        view(iid=invitation.iid)
+        mail = Mailing(self.portal).pop()
+        self.assertIn('Content-Type: text/plain; charset="utf-8"', mail)
+        self.assertIn('Content-Type: text/html; charset="utf-8"', mail)
+        self.assertIn('Content-Type: text/html; charset="utf-8"', mail)
+        regex = re.compile(r'Subject: =\?utf-?8\?q\?The_Invitation_to_participate_in_Plone_site_was_accepted_by_Lei')
+        match = regex.search(mail)
+        self.assertTrue(match)
+        self.assertIn('To: =?utf-8?q?Bond_James?= <james@bond.com>', mail)

--- a/ftw/participation/tests/test_browser_participants.py
+++ b/ftw/participation/tests/test_browser_participants.py
@@ -76,7 +76,7 @@ class TestParticipantsView(TestCase):
                .inviting(juergen)
                .to(self.folder)
                .invited_by(fraenzi))
-
+        
         browser.login().visit(self.folder, view='participants')
         self.assertEquals([u'Doe John (john@doe.com)',
                            u'jurgen@ruegsegger.com',

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(name='ftw.participation',
         'plone.z3cform',
         'setuptools',
         'z3c.form',
+        'ftw.builder',
         ],
 
       tests_require=tests_require,

--- a/sources.cfg
+++ b/sources.cfg
@@ -1,0 +1,5 @@
+[buildout]
+extends = http://plonesource.org/sources.cfg
+extensions = mr.developer
+
+auto-checkout =

--- a/test-plone-4.1.x.cfg
+++ b/test-plone-4.1.x.cfg
@@ -2,5 +2,9 @@
 extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.1.x.cfg
     http://good-py.appspot.com/release/plone.app.z3cform/0.5.0-1?plone=4.1.5
+    sources.cfg
 
 package-name = ftw.participation
+
+versions=versions
+

--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -1,5 +1,9 @@
 [buildout]
 extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
+    sources.cfg
 
 package-name = ftw.participation
+
+versions=versions
+

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -1,5 +1,9 @@
 [buildout]
 extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
+    sources.cfg
 
 package-name = ftw.participation
+
+versions=versions
+


### PR DESCRIPTION
@buchi I changed the encoding of the mail so it works with umlauts in outlook. I didn't put mail generation in one place since I think this should be done over all our products so we have to solve the problems only once.
