### PR TITLE
Add dexterity support.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.1.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add dexterity support.
+  [jone]
 
 
 1.1.3 (2014-01-09)


### PR DESCRIPTION
This adds dexterity support to ftw.participation, meaning that invitations can be created for dexterity objects too.
The change is mainly using plone.app.uuid instead of the AT UIDs.

Since dexterity objects are not in the reference_catalog, the lookup implementation is changed to using the portal_catalog.
When looking up the object, it is necessary that the security is not checked (as it was before) because this usually happens in the security context of the invited person, which has not yet permissions on the target (because that's what the invitation is for).

// @maethu 
