### PR TITLE
Do not set reader role when not using multiple role option

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,10 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- When allow_multiple_roles is disabled, the Reader role should
+  not be added to the selected role as default role, since it
+  does not make sense to have multiple roles in this case.
+  [jone]
 
 
 1.3.0 (2014-03-14)

--- a/ftw/participation/setter.py
+++ b/ftw/participation/setter.py
@@ -1,5 +1,8 @@
 from ftw.participation import interfaces
+from ftw.participation.interfaces import IParticipationRegistry
+from plone.registry.interfaces import IRegistry
 from zope.component import adapts
+from zope.component import getUtility
 from zope.interface import Interface
 from zope.interface import implements
 import AccessControl
@@ -67,7 +70,14 @@ class DefaultParticipationSetter(object):
         """List of roles to give the `self.user` on the `self.context`.
         Reader ist default, and must be set.
         """
-        default_role = ['Reader', ]
+        registry = getUtility(IRegistry)
+        config = registry.forInterface(IParticipationRegistry)
+
+        if config.allow_multiple_roles:
+            default_role = ['Reader', ]
+        else:
+            default_role = []
+
         if hasattr(self.invitation, 'roles'):
             return list(self.invitation.roles) + default_role
         return default_role

--- a/ftw/participation/tests/test_accept.py
+++ b/ftw/participation/tests/test_accept.py
@@ -1,18 +1,21 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.participation.interfaces import IParticipationRegistry
 from ftw.participation.interfaces import IParticipationSupport
 from ftw.participation.invitation import Invitation
-from ftw.participation.tests.layer import FTW_PARTICIPATION_INTEGRATION_TESTING
+from ftw.participation.tests import layer
 from ftw.testing.mailing import Mailing
 from plone.app.testing import login
+from plone.registry.interfaces import IRegistry
 from unittest2 import TestCase
+from zope.component import getUtility
 from zope.interface import alsoProvides
 import email
 
 
 class TestAcceptInvitation(TestCase):
 
-    layer = FTW_PARTICIPATION_INTEGRATION_TESTING
+    layer = layer.FTW_PARTICIPATION_INTEGRATION_TESTING
 
     def setUp(self):
         self.portal = self.layer['portal']
@@ -49,3 +52,59 @@ class TestAcceptInvitation(TestCase):
         self.assertRegexpMatches(
             message.get('Subject'),
             r'^=\?utf-?8\?q\?The_Invitation_to_')
+
+    def test_accepting_sets_roles_on_context(self):
+        login(self.portal, 'james.bond')
+        invitation = Invitation(target=self.folder,
+                                email='felix@leiter.com',
+                                inviter='james.bond',
+                                roles=['Reader', 'Contributor'])
+
+        login(self.portal, 'felix.leiter')
+        view = self.portal.restrictedTraverse('accept_invitation')
+        view(iid=invitation.iid)
+
+        self.assertItemsEqual(
+            ['Reader', 'Contributor'],
+            dict(self.folder.get_local_roles()).get('felix.leiter'))
+
+    def test_Reader_role_is_added_by_default(self):
+        login(self.portal, 'james.bond')
+        invitation = Invitation(target=self.folder,
+                                email='felix@leiter.com',
+                                inviter='james.bond',
+                                roles=['Contributor'])
+
+        login(self.portal, 'felix.leiter')
+        view = self.portal.restrictedTraverse('accept_invitation')
+        view(iid=invitation.iid)
+
+        self.assertItemsEqual(
+            ['Reader', 'Contributor'],
+            dict(self.folder.get_local_roles()).get('felix.leiter'))
+
+    def test_Reader_role_is_not_added_when_multiple_roles_disabled(self):
+        # When allow_multiple_roles is disabled (default is enabled), we
+        # only want to have one single role set.
+        # In this case the default Reader role should not be appended,
+        # otherwise we would have multiple roles against the configuration,
+        # producing problems such as when changing roles with
+        # radio buttons.
+
+        registry = getUtility(IRegistry)
+        config = registry.forInterface(IParticipationRegistry)
+        config.allow_multiple_roles = False
+
+        login(self.portal, 'james.bond')
+        invitation = Invitation(target=self.folder,
+                                email='felix@leiter.com',
+                                inviter='james.bond',
+                                roles=['Contributor'])
+
+        login(self.portal, 'felix.leiter')
+        view = self.portal.restrictedTraverse('accept_invitation')
+        view(iid=invitation.iid)
+
+        self.assertItemsEqual(
+            ['Contributor'],
+            dict(self.folder.get_local_roles()).get('felix.leiter'))


### PR DESCRIPTION
When allow_multiple_roles is disabled, the Reader role should not be added to the selected role as default role, since it does not make sense to have multiple roles in this case.

/ @maethu 
