### PR TITLE
don't encode email address. only the name

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,8 @@ Changelog
 1.3.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Do not encode from address only name.
+  [tschanzt]
 
 1.3.2 (2014-06-02)
 ------------------
@@ -16,6 +16,7 @@ Changelog
 
 - Make sure the participation-tab has no manipulation control elements
   if IParticipationSupport is not active.
+  [mathias.leimgruber]
 
 - The participants-tab now also works without IParticipationSupport (read only).
   [mathias.leimgruber]

--- a/ftw/participation/browser/accept.py
+++ b/ftw/participation/browser/accept.py
@@ -78,7 +78,7 @@ class AcceptInvitation(BrowserView):
         mtool = getToolByName(self.context, 'portal_membership')
         # prepare from address for header
         from_str = Header(properties.email_from_name, 'utf-8')
-        from_str.append('<%s>' % properties.email_from_address)
+        from_str.append(u'<%s>' % properties.email_from_address.decode('utf-8'))
 
         # To
         to_member = mtool.getMemberById(self.invitation.inviter)

--- a/ftw/participation/tests/test_accept.py
+++ b/ftw/participation/tests/test_accept.py
@@ -26,6 +26,11 @@ class TestAcceptInvitation(TestCase):
         create(Builder('user').named('James', 'Bond'))
 
         Mailing(self.layer['portal']).set_up()
+        
+        self.portal.manage_changeProperties(
+            {'email_from_name': 'Plone Admin',
+             'email_from_address': 'plone@plone.local'})
+             
 
     def tearDown(self):
         Mailing(self.layer['portal']).tear_down()
@@ -48,6 +53,9 @@ class TestAcceptInvitation(TestCase):
 
         self.assertEquals('=?utf-8?q?Bond_James?= <james@bond.com>',
                           message.get('To'))
+
+        self.assertEquals('=?utf-8?q?Plone_Admin?= <plone@plone.local>',
+                          message.get('From'))
 
         self.assertRegexpMatches(
             message.get('Subject'),


### PR DESCRIPTION
@buchi This should fix the strange behavior of the From address.
The problem was the difference in the behaviour in the python email header when given unicode or bytestring. If it is given a bytestring it is always encoded, but if given a unicode string it will only encode if it can't enode it with ascii. This is what we want when giving an email address. 
