### PR TITLE
Participants: hide users without roles.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,10 @@ Changelog
 1.3.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Participants: hide users without roles.
+  This can happen when inheriting the Owner, because inherited Owner
+  roles are removed.
+  [jone]
 
 
 1.3.3 (2014-08-07)

--- a/ftw/participation/browser/participants.py
+++ b/ftw/participation/browser/participants.py
@@ -185,7 +185,9 @@ class ManageParticipants(BrowserView):
                     item['name'] = name.decode('utf-8')
                 else:
                     item['name'] = userid.decode('utf-8')
-                users.append(item)
+
+                if item.get('roles') or item.get('inherited_roles'):
+                    users.append(item)
 
         users.sort(key=lambda item: item['name'].lower())
         return users

--- a/ftw/participation/tests/test_participants.py
+++ b/ftw/participation/tests/test_participants.py
@@ -324,10 +324,12 @@ class TestParticipation(TestCase):
         del subfolder.__ac_local_roles__[TEST_USER_ID]
         subfolder._p_changed=True
 
+        subfolder.manage_setLocalRoles(TEST_USER_ID, ['Editor'])
+
         expect = [{'name': unicode(TEST_USER_ID),
                    'userid': TEST_USER_ID,
                    'readonly': True,
-                   'roles': [],
+                   'roles': ['Can edit'],
                    'inherited_roles': [],
                    'type_': 'userids'}, ]
 
@@ -335,3 +337,19 @@ class TestParticipation(TestCase):
         self.maxDiff = None
         self.assertEquals(expect, view.get_participants())
 
+    def test_exclude_inherited_users_without_roles(self):
+
+        folder = create(Builder('folder')
+                        .titled('Folder'))
+
+        subfolder = create(Builder('folder')
+                           .within(folder)
+                           .titled('Subfolder')
+                           .providing(IParticipationSupport))
+        del subfolder.__ac_local_roles__[TEST_USER_ID]
+        subfolder._p_changed=True
+
+        expect = []
+        view = subfolder.restrictedTraverse('@@participants')
+        self.maxDiff = None
+        self.assertEquals(expect, view.get_participants())


### PR DESCRIPTION
The inherited roles are displayed in general, but the inherited `Owner` role is removed (because it is not relevant in Zope's security).
When a user is only the `Owner` of a parent, the user was displayed without any roles.
This change removes all users if the have neither local roles nor inherited roles.

@maethu 
