### PR TITLE
Participants: fix table layout for read-only users.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.3.4 (unreleased)
 ------------------
 
+- Participants: fix table layout for read-only users.
+  [jone]
+
 - Participants: hide users without roles.
   This can happen when inheriting the Owner, because inherited Owner
   roles are removed.

--- a/ftw/participation/browser/participants_form.pt
+++ b/ftw/participation/browser/participants_form.pt
@@ -43,7 +43,7 @@
                             </span><tal:comma tal:condition="not: repeat/role/end">,</tal:comma>
                         </tal:block>
                       </td>
-                      <td tal:condition="view/can_manage" tal:content="python:item.get('inviter', '&nbsp;')" />
+                      <td tal:condition="view/has_participation_support" tal:content="python:item.get('inviter', '&nbsp;')" />
                       <tal:if condition="view/has_participation_support">
                           <td tal:condition="python:item.get('userid', None)" i18n:translate="label_accepted">
                               Accepted


### PR DESCRIPTION
The content-cell condition did not match the heading-cell condition.
The result was that the "invited by" column was missing and in invalid markup:
![bildschirmfoto 2014-08-07 um 13 41 53](https://cloud.githubusercontent.com/assets/7469/3841148/dc7053a2-1e27-11e4-8cf4-21eaf3245281.png)

@maethu 
