### PR TITLE
BugFix: Pass email_from as string, not as email.header instance.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
+- BugFix: Pass email_from as string, not as email.header instance.
+  This fixes sending emails with an Exchange.
+  [mathias.leimgruber]
+
 - Do not show invite link, if internal user and email invitation is disabled.
   [mathias.leimgruber]
 

--- a/ftw/participation/browser/invite.py
+++ b/ftw/participation/browser/invite.py
@@ -307,7 +307,7 @@ class InviteForm(Form):
         # make the mail
         msg = MIMEMultipart('alternative')
         msg['Subject'] = header_subject
-        msg['From'] = header_from
+        msg['From'] = str(header_from)
         msg['To'] = email
 
         # render and embedd html / text


### PR DESCRIPTION
[The accept mail sender does the same](https://github.com/4teamwork/ftw.participation/blob/master/ftw/participation/browser/accept.py#L120)

Fixes #38 

@jone @lukasgraf 
