### PR TITLE
Fix condition for invite_participants view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.3.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix condition for invite_participants view.
+  Only raise NotFound if both options (invite email/member) are disabled.
+  [mathias.leimgruber]
 
 
 1.3.6 (2014-12-08)

--- a/ftw/participation/browser/invite.py
+++ b/ftw/participation/browser/invite.py
@@ -181,7 +181,7 @@ class InviteForm(Form):
         registry = getUtility(IRegistry)
         config = registry.forInterface(IParticipationRegistry)
 
-        if not (config.allow_invite_email and config.allow_invite_users):
+        if not (config.allow_invite_email or config.allow_invite_users):
             raise NotFound
 
         if config.allow_multiple_roles:


### PR DESCRIPTION
Only raise NotFound if both options (invite email/member) are disabled.
