### PR TITLE
Test setup: change extends order

### DIFF
--- a/test-plone-4.1.x.cfg
+++ b/test-plone-4.1.x.cfg
@@ -1,10 +1,9 @@
 [buildout]
 extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.1.x.cfg
     http://good-py.appspot.com/release/plone.app.z3cform/0.5.0-1?plone=4.1.5
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.1.x.cfg
     sources.cfg
 
 package-name = ftw.participation
 
 versions=versions
-


### PR DESCRIPTION
To make sure that the `ftw-buildouts` version pinnings (zc.buildout etc.) are handled with priority.

@jone