### PR TITLE
support for ftw.activity

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,7 +7,7 @@ Changelog
 
 - Add events. [jone]
 
-- Drop Plone 4.1 support. [jone]
+- Drop Plone 4.1 and 4.2 support. [jone]
 
 
 1.3.8 (2016-11-11)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.3.9 (unreleased)
 ------------------
 
+- Add ftw.activity support for participation events. [jone]
+
 - Add events. [jone]
 
 - Drop Plone 4.1 and 4.2 support. [jone]

--- a/ftw/participation/activity/configure.zcml
+++ b/ftw/participation/activity/configure.zcml
@@ -3,6 +3,9 @@
     xmlns:i18n="http://namespaces.zope.org/i18n"
     i18n_domain="ftw.participation">
 
+    <adapter
+        factory=".renderer.InvitationRenderer"
+        name="ftw.participant:invitations" />
 
     <subscriber
         for="* ftw.participation.events.IInvitationCreatedEvent"

--- a/ftw/participation/activity/configure.zcml
+++ b/ftw/participation/activity/configure.zcml
@@ -1,0 +1,37 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    i18n_domain="ftw.participation">
+
+
+    <subscriber
+        for="* ftw.participation.events.IInvitationCreatedEvent"
+        handler=".subscribers.invitation_created"
+        />
+
+    <subscriber
+        for="* ftw.participation.events.IInvitationAcceptedEvent"
+        handler=".subscribers.invitation_accepted"
+        />
+
+    <subscriber
+        for="* ftw.participation.events.IInvitationRejectedEvent"
+        handler=".subscribers.invitation_rejected"
+        />
+
+    <subscriber
+        for="* ftw.participation.events.IInvitationRetractedEvent"
+        handler=".subscribers.invitation_retracted"
+        />
+
+    <subscriber
+        for="* ftw.participation.events.IRolesChangedEvent"
+        handler=".subscribers.role_changed"
+        />
+
+    <subscriber
+        for="* ftw.participation.events.ILocalRoleRemoved"
+        handler=".subscribers.role_removed"
+        />
+
+</configure>

--- a/ftw/participation/activity/renderer.py
+++ b/ftw/participation/activity/renderer.py
@@ -1,0 +1,89 @@
+from ftw.activity.browser.renderer import DefaultRenderer
+from zope.component.hooks import getSite
+from ftw.participation import _
+from ftw.participation.activity.utils import translate_and_join_roles
+from Products.CMFCore.utils import getToolByName
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+
+
+class InvitationRenderer(DefaultRenderer):
+    index = ViewPageTemplateFile('templates/invitation.pt')
+
+    def position(self):
+        return 900
+
+    def match(self, activity, obj):
+        return activity.attrs['action'].startswith('participation:')
+
+    def render(self, activity, obj):
+        return self.index(activity=activity,
+                          obj=obj,
+                          comment=self.prepare_comment(activity))
+
+    def prepare_comment(self, activity):
+        action = activity.attrs['action']
+
+        if action == 'participation:invitation_created':
+            actor_info = activity.get_actor_info()
+            roles = translate_and_join_roles(
+                activity.attrs['invitation:roles'], self.request)
+
+            return _(u'activity_invitation_created_body',
+                     default=u'${inviter} has invited ${mail} as ${roles}.',
+                     mapping={'inviter': actor_info.get('fullname'),
+                              'mail': activity.attrs['invitation:email'],
+                              'roles': roles})
+
+        if action == 'participation:invitation_retracted':
+            actor_info = activity.get_actor_info()
+            roles = translate_and_join_roles(
+                activity.attrs['invitation:roles'], self.request)
+
+            return _(u'activity_invitation_retracted_body',
+                     default=u'${actor} has retracted the invitation'
+                     u' for ${mail}.',
+                     mapping={'actor': actor_info.get('fullname'),
+                              'mail': activity.attrs['invitation:email']})
+
+        if action == 'participation:role_changed':
+            actor_info = activity.get_actor_info()
+            subject_fullname = self.get_fullname_of(
+                activity.attrs['roles:userid'])
+            removed_roles = translate_and_join_roles(
+                activity.attrs['roles:removed'], self.request)
+            added_roles = translate_and_join_roles(
+                activity.attrs['roles:added'], self.request)
+
+            return _(u'activity_role_changed_body',
+                     default=u'${actor} has changed the role of ${subject}'
+                     u' from ${removed_roles} to ${added_roles}.',
+                     mapping={'actor': actor_info.get('fullname'),
+                              'subject': subject_fullname,
+                              'removed_roles': removed_roles,
+                              'added_roles': added_roles})
+
+        if action == 'participation:role_removed':
+            actor_info = activity.get_actor_info()
+            subject_fullname = self.get_fullname_of(
+                activity.attrs['roles:userid'])
+
+            return _(u'activity_participant_removed_body',
+                     default=u'${actor} has removed the'
+                     u' participant ${subject}.',
+                     mapping={'actor': actor_info.get('fullname'),
+                              'subject': subject_fullname})
+
+        return None
+
+    def get_fullname_of(self, userid):
+        membership = getToolByName(getSite(), 'portal_membership')
+        member = membership.getMemberById(userid)
+        if not member:
+            result = userid or 'N/A'
+        else:
+            result = member.getProperty('fullname') or userid
+
+        if not isinstance(result, unicode):
+            result = result.decode('utf-8')
+
+        return result

--- a/ftw/participation/activity/subscribers.py
+++ b/ftw/participation/activity/subscribers.py
@@ -1,0 +1,57 @@
+from ftw.activity.catalog import get_activity_soup
+from ftw.activity.catalog.record import ActivityRecord
+
+
+def create_record_from_invitation(obj, invitation, action,
+                                  actor_userid=None, date=None):
+    record = ActivityRecord(obj, action,
+                            actor_userid=actor_userid, date=date)
+    record.attrs['invitation:inviter'] = invitation.inviter
+    record.attrs['invitation:email'] = invitation.email
+    record.attrs['invitation:roles'] = tuple(invitation.roles)
+    return record
+
+
+def invitation_created(obj, event, actor_userid=None, date=None):
+    record = create_record_from_invitation(
+        obj, event.invitation, 'participation:invitation_created')
+    record.attrs['invitation:comment'] = event.comment
+    return get_activity_soup().add(record)
+
+
+def invitation_accepted(obj, event, actor_userid=None, date=None):
+    record = create_record_from_invitation(
+        obj, event.invitation, 'participation:invitation_accepted')
+    return get_activity_soup().add(record)
+
+
+def invitation_rejected(obj, event, actor_userid=None, date=None):
+    record = create_record_from_invitation(
+        obj, event.invitation, 'participation:invitation_rejected')
+    return get_activity_soup().add(record)
+
+
+def invitation_retracted(obj, event, actor_userid=None, date=None):
+    record = create_record_from_invitation(
+        obj, event.invitation, 'participation:invitation_retracted')
+    return get_activity_soup().add(record)
+
+
+def role_changed(obj, event, actor_userid=None, date=None):
+    record = ActivityRecord(obj, 'participation:role_changed',
+                            actor_userid=actor_userid, date=date)
+    record.attrs['roles:userid'] = event.userid
+    record.attrs['roles:old'] = tuple(event.old_roles)
+    record.attrs['roles:new'] = tuple(event.new_roles)
+    record.attrs['roles:removed'] = tuple(
+        set(event.old_roles) - set(event.new_roles))
+    record.attrs['roles:added'] = tuple(
+        set(event.new_roles) - set(event.old_roles))
+    return get_activity_soup().add(record)
+
+
+def role_removed(obj, event, actor_userid=None, date=None):
+    record = ActivityRecord(obj, 'participation:role_removed',
+                            actor_userid=actor_userid, date=date)
+    record.attrs['roles:userid'] = event.userid
+    return get_activity_soup().add(record)

--- a/ftw/participation/activity/templates/invitation.pt
+++ b/ftw/participation/activity/templates/invitation.pt
@@ -1,0 +1,6 @@
+<metal:wrapper use-macro="context/@@activity_macros/macros/event">
+    <metal:BODY metal:fill-slot="body">
+        <div class="participation-body-comment"
+             tal:content="options/comment|nothing" />
+    </metal:BODY>
+</metal:wrapper>

--- a/ftw/participation/activity/utils.py
+++ b/ftw/participation/activity/utils.py
@@ -1,0 +1,9 @@
+from ftw.participation import _
+from ftw.participation.browser.participants import get_friendly_role_names
+from zope.i18n import translate
+
+
+def translate_and_join_roles(roles, request):
+    roles = get_friendly_role_names(roles, request)
+    and_ = translate(_(' and '), context=request)
+    return ', '.join(roles[:-2] + [and_.join(roles[-2:])])

--- a/ftw/participation/configure.zcml
+++ b/ftw/participation/configure.zcml
@@ -17,8 +17,8 @@
 
     <!-- include sub module zcmls -->
     <include package=".browser" />
-
     <include package=".upgrades" />
+    <include package=".activity" zcml:condition="installed ftw.activity" />
 
     <!-- register translations -->
     <i18n:registerTranslations directory="locales" />

--- a/ftw/participation/locales/de/LC_MESSAGES/ftw.activity.po
+++ b/ftw/participation/locales/de/LC_MESSAGES/ftw.activity.po
@@ -1,0 +1,33 @@
+# --- PLEASE EDIT THE LINES BELOW CORRECTLY ---
+# SOME DESCRIPTIVE TITLE.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2014-03-12 10:43+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"Preferred-Encodings: utf-8 latin1\n"
+
+msgid "participation:invitation_accepted"
+msgstr "Einladung akzeptiert"
+
+msgid "participation:invitation_created"
+msgstr "Einladung erstellt"
+
+msgid "participation:invitation_rejected"
+msgstr "Einladung abgelehnt"
+
+msgid "participation:invitation_retracted"
+msgstr "Einladung zurückgezogen"
+
+msgid "participation:role_changed"
+msgstr "Rolle geändert"
+
+msgid "participation:role_removed"
+msgstr "Beteiligung entfernt"

--- a/ftw/participation/locales/de/LC_MESSAGES/ftw.participation.po
+++ b/ftw/participation/locales/de/LC_MESSAGES/ftw.participation.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-11-11 14:15+0000\n"
+"POT-Creation-Date: 2016-11-29 21:13+0000\n"
 "PO-Revision-Date: 2010-09-08 18:05+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -11,15 +11,19 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
 
+#: ./ftw/participation/activity/utils.py:8
+msgid " and "
+msgstr " und "
+
 #: ./ftw/participation/browser/invitations.pt:68
 msgid "Accept"
 msgstr "Akzeptieren"
 
-#: ./ftw/participation/browser/participants.py:62
+#: ./ftw/participation/browser/participants.py:67
 msgid "Changes saved."
 msgstr "Änderungen wurden Gespeichert"
 
-#: ./ftw/participation/browser/invite.py:125
+#: ./ftw/participation/browser/invite.py:127
 msgid "Enter at least one e-mail address."
 msgstr "Geben Sie mindestens eine E-Mail Adresse an."
 
@@ -37,7 +41,7 @@ msgstr "Meine Einladungen"
 
 #: ./ftw/participation/configure.zcml:34
 msgid "Participation and invitation support"
-msgstr ""
+msgstr "Unterstützung für Beteiligung und Einladung"
 
 #: ./ftw/participation/browser/invitations.pt:71
 msgid "Reject"
@@ -51,11 +55,11 @@ msgstr ""
 msgid "Retract"
 msgstr "Widerrufen"
 
-#: ./ftw/participation/browser/invite.py:122
+#: ./ftw/participation/browser/invite.py:124
 msgid "Select at least one user or enter at least one e-mail address"
 msgstr "Wählen Sie mindestens eine Person aus oder geben Sie mindestens eine E-Mail Adresse an."
 
-#: ./ftw/participation/browser/invite.py:127
+#: ./ftw/participation/browser/invite.py:129
 msgid "Select at least one user."
 msgstr "Wählen Sie mindestens ein Benutzer aus."
 
@@ -75,9 +79,29 @@ msgstr "Guten Tag, ${inviter_name}"
 msgid "accepted_mail_text"
 msgstr "Ihre Einladung um an ${context_title} teilzunehmen wurde von ${invited_name} akzeptiert"
 
+#. Default: "${inviter} has invited ${mail} as ${roles}."
+#: ./ftw/participation/activity/renderer.py:31
+msgid "activity_invitation_created_body"
+msgstr "${inviter} hat ${mail} als ${roles} eingeladen."
+
+#. Default: "${actor} has retracted the invitation for ${mail}."
+#: ./ftw/participation/activity/renderer.py:42
+msgid "activity_invitation_retracted_body"
+msgstr "${actor} hat die Einladung an ${mail} zurückgezogen."
+
+#. Default: "${actor} has removed the participant ${subject}."
+#: ./ftw/participation/activity/renderer.py:70
+msgid "activity_participant_removed_body"
+msgstr "${actor} hat den Teilnehmer ${subject} entfernt."
+
+#. Default: "${actor} has changed the role of ${subject} from ${removed_roles} to ${added_roles}."
+#: ./ftw/participation/activity/renderer.py:57
+msgid "activity_role_changed_body"
+msgstr "${actor} hat die Rolle von ${subject} von ${removed_roles} zu ${added_roles} geändert."
+
 #. Default: "Cancel"
-#: ./ftw/participation/browser/changeroles.py:102
-#: ./ftw/participation/browser/invite.py:262
+#: ./ftw/participation/browser/changeroles.py:110
+#: ./ftw/participation/browser/invite.py:266
 #: ./ftw/participation/browser/participants_form.pt:83
 msgid "button_cancel"
 msgstr "Abbrechen"
@@ -88,43 +112,43 @@ msgid "button_delete_participants"
 msgstr "Personen löschen"
 
 #. Default: "Invite"
-#: ./ftw/participation/browser/invite.py:216
+#: ./ftw/participation/browser/invite.py:218
 msgid "button_invite"
 msgstr "Einladen"
 
 #. Default: "Save"
-#: ./ftw/participation/browser/changeroles.py:89
+#: ./ftw/participation/browser/changeroles.py:91
 msgid "button_save"
 msgstr "Speichern"
 
 #. Default: "At least one of the defined addresses are not valid."
-#: ./ftw/participation/browser/invite.py:99
+#: ./ftw/participation/browser/invite.py:101
 msgid "error_invalid_addresses"
 msgstr "Mindestens eine der eingegebenen Adressen ist ungültig"
 
 #. Default: "Could not find the invitation."
-#: ./ftw/participation/browser/accept.py:60
-#: ./ftw/participation/browser/retract.py:46
+#: ./ftw/participation/browser/accept.py:63
+#: ./ftw/participation/browser/retract.py:49
 msgid "error_invitation_not_found"
 msgstr "Die Einladung konnte nicht gefunden werden"
 
 #. Default: "Invitor could not be notified: he has no email address defined."
-#: ./ftw/participation/browser/accept.py:86
+#: ./ftw/participation/browser/accept.py:89
 msgid "error_inviter_email_missing"
 msgstr "Die einladende Person konnte nicht benachrichtigt werden: Er hat keine E-Mail-Adresse definiert"
 
 #. Default: "Please select a role"
-#: ./ftw/participation/browser/invite.py:162
+#: ./ftw/participation/browser/invite.py:164
 msgid "error_no_roles"
 msgstr "Bitte wählen Sie eine Berechtigung aus."
 
 #. Default: "The participation quota is reached, you cannot add any further participants."
-#: ./ftw/participation/browser/invite.py:135
+#: ./ftw/participation/browser/invite.py:137
 msgid "error_participation_quota_reached"
 msgstr "Die Maximale Teilnehmerzahl ist erreicht, Sie können keine Teilnehmer mehr hinzufügen"
 
 #. Default: "You cannot invite so many participants any more. Can only add ${num} more participants."
-#: ./ftw/participation/browser/invite.py:139
+#: ./ftw/participation/browser/invite.py:141
 msgid "error_too_many_participants"
 msgstr "Sie können nicht mehr so viele Teilnehmer einladen. Sie können maximal ${num} Einladungen versenden."
 
@@ -157,27 +181,27 @@ msgid "headline_sent_invitations"
 msgstr "Versendete Einladungen"
 
 #. Default: "Enter one e-mail address per line"
-#: ./ftw/participation/browser/invite.py:49
+#: ./ftw/participation/browser/invite.py:51
 msgid "help_addresses"
 msgstr "Um neue Personen einzuladen, geben Sie eine E-Mail Adresse pro Zeile ein"
 
 #. Default: "Allow to invite participants by typing the e-mail address in the invitation form. It is recommended to enable registriation in plone security"
-#: ./ftw/participation/interfaces.py:26
+#: ./ftw/participation/interfaces.py:28
 msgid "help_allow_invite_email"
 msgstr "Nicht registrierte Personen können per E-Mail Adresse eingeladen werden."
 
 #. Default: "Allow to search users from PAS in invitation form."
-#: ./ftw/participation/interfaces.py:18
+#: ./ftw/participation/interfaces.py:20
 msgid "help_allow_invite_users"
 msgstr "Bestehende Benutzer können durchsucht und eingeladen werden."
 
 #. Default: "Enter a comment which will be contained in the invitaiton E-Mail"
-#: ./ftw/participation/browser/invite.py:61
+#: ./ftw/participation/browser/invite.py:63
 msgid "help_comment"
 msgstr "Dieser Kommentar wird ins Einladungs-E-Mail eingefügt."
 
 #. Default: "Allow to pass multiple roles to a invited user."
-#: ./ftw/participation/interfaces.py:35
+#: ./ftw/participation/interfaces.py:37
 msgid "help_multiple_roles"
 msgstr "Erlaubt das selektieren mehrerer Rollen beim Einladen."
 
@@ -186,27 +210,27 @@ msgid "help_participation_quota_limit"
 msgstr "Mit hilfe des Quota limits können Sie die maximale Teilnehmerzahl definieren"
 
 #. Default: "Select users to invite."
-#: ./ftw/participation/browser/invite.py:41
+#: ./ftw/participation/browser/invite.py:43
 msgid "help_users"
 msgstr "Wählen Sie einen oder mehrere Personen aus. Sie können nach der E-Mail Adresse oder Vor bzw. Nachnamen suchen"
 
 #. Default: "You have accepted the invitation."
-#: ./ftw/participation/browser/accept.py:33
+#: ./ftw/participation/browser/accept.py:36
 msgid "info_invitation_accepted"
 msgstr "Sie haben die Einladung akzeptiert"
 
 #. Default: "You have rejected the invitation."
-#: ./ftw/participation/browser/reject.py:26
+#: ./ftw/participation/browser/reject.py:29
 msgid "info_invitation_rejected"
 msgstr "Sie haben die Einladung abgelehnt"
 
 #. Default: "You have retracted the invitation."
-#: ./ftw/participation/browser/retract.py:20
+#: ./ftw/participation/browser/retract.py:23
 msgid "info_invitation_retracted"
 msgstr "Sie haben die Einladung widerrufen"
 
 #. Default: "The invitation mails were sent to ${emails}."
-#: ./ftw/participation/browser/invite.py:256
+#: ./ftw/participation/browser/invite.py:260
 msgid "info_invitations_sent"
 msgstr "Die Einladungen wurden per E-Mail an ${emails} versendet."
 
@@ -255,17 +279,17 @@ msgid "label_accepted"
 msgstr "Angenommen"
 
 #. Default: "E-Mail Addresses"
-#: ./ftw/participation/browser/invite.py:48
+#: ./ftw/participation/browser/invite.py:50
 msgid "label_addresses"
 msgstr "E-Mail Adressen"
 
 #. Default: "Allow to invite participants by email"
-#: ./ftw/participation/interfaces.py:24
+#: ./ftw/participation/interfaces.py:26
 msgid "label_allow_invite_email"
 msgstr "Fremde Benutzer beteiligen"
 
 #. Default: "Allow to invite users"
-#: ./ftw/participation/interfaces.py:16
+#: ./ftw/participation/interfaces.py:18
 msgid "label_allow_invite_users"
 msgstr "Existierende Benutzer beteiligen"
 
@@ -275,17 +299,17 @@ msgid "label_change"
 msgstr "ändern"
 
 #. Default: "Change roles"
-#: ./ftw/participation/browser/changeroles.py:50
+#: ./ftw/participation/browser/changeroles.py:52
 msgid "label_changerole_form"
 msgstr "Rollen anpassen"
 
 #. Default: "Comment"
-#: ./ftw/participation/browser/invite.py:60
+#: ./ftw/participation/browser/invite.py:62
 msgid "label_comment"
 msgstr "Kommentar"
 
 #. Default: "Invite Participants"
-#: ./ftw/participation/browser/invite.py:171
+#: ./ftw/participation/browser/invite.py:173
 msgid "label_invite_participants"
 msgstr "Personen einladen"
 
@@ -300,7 +324,7 @@ msgid "label_local_roles"
 msgstr "Rollen"
 
 #. Default: "Allow to give multiple roles"
-#: ./ftw/participation/interfaces.py:33
+#: ./ftw/participation/interfaces.py:35
 msgid "label_multiple_roles"
 msgstr "Mehrere Rollen aktivieren"
 
@@ -315,8 +339,8 @@ msgid "label_pending"
 msgstr "offen"
 
 #. Default: "Roles"
-#: ./ftw/participation/browser/changeroles.py:40
-#: ./ftw/participation/browser/invite.py:54
+#: ./ftw/participation/browser/changeroles.py:42
+#: ./ftw/participation/browser/invite.py:56
 msgid "label_roles"
 msgstr "Rollen"
 
@@ -331,7 +355,7 @@ msgid "label_user"
 msgstr "Benutzer"
 
 #. Default: "Users"
-#: ./ftw/participation/browser/invite.py:40
+#: ./ftw/participation/browser/invite.py:42
 msgid "label_users"
 msgstr "Benutzer"
 
@@ -351,22 +375,22 @@ msgid "link_reject_invitation"
 msgstr "Nein, ich möchte nicht teilnehmen"
 
 #. Default: "The Invitation to participate in ${title} was accepted by ${user}"
-#: ./ftw/participation/browser/accept.py:154
+#: ./ftw/participation/browser/accept.py:157
 msgid "mail_invitation_accepted_subject"
 msgstr "Die Einladung um an ${title} teilzunehmen wurde von ${user} akzeptiert"
 
 #. Default: "The Invitation to participate in ${title} was rejected by ${user}"
-#: ./ftw/participation/browser/reject.py:58
+#: ./ftw/participation/browser/reject.py:61
 msgid "mail_invitation_rejected_subject"
 msgstr "Die Einladung um an ${title} teilzunehmen wurde von ${user} abgelehnt"
 
 #. Default: "Invitation for paticipating in ${title}"
-#: ./ftw/participation/browser/invite.py:329
+#: ./ftw/participation/browser/invite.py:333
 msgid "mail_invitation_subject"
 msgstr "Einladung zur Teilnahme an ${title}"
 
 #. Default: "Changed roles"
-#: ./ftw/participation/browser/changeroles.py:120
+#: ./ftw/participation/browser/changeroles.py:128
 msgid "message_roles_changes"
 msgstr "Rollen wurden angepasst."
 
@@ -388,7 +412,7 @@ msgid "text_infos_participants"
 msgstr "Stellen Sie Ihr Team für den aktuellen Teamraum zusammen. Die Tabelle zeigt alle involvierten Personen. Klicken sie auf \"Personen einladen\" um Ihr Team zu vergrössern."
 
 #. Default: "Use this form to invide new user"
-#: ./ftw/participation/browser/invite.py:173
+#: ./ftw/participation/browser/invite.py:175
 msgid "text_invite_new"
 msgstr "Mit diesem Formular können Sie neue Personen einladen. Nach dem Klicken auf \"Einladen\", werden an die ausgewählten Personen E-Mails mit den Einladungen versendet."
 
@@ -416,4 +440,3 @@ msgstr "Sie haben die folgenden Benutzer eingeladen. Sie haben bis jetzt die Ein
 #: ./ftw/participation/browser/invitations.py:111
 msgid "warning_invitaiton_expired"
 msgstr "Die Einladung ist abgelaufen"
-

--- a/ftw/participation/locales/en/LC_MESSAGES/ftw.activity.po
+++ b/ftw/participation/locales/en/LC_MESSAGES/ftw.activity.po
@@ -1,0 +1,33 @@
+# --- PLEASE EDIT THE LINES BELOW CORRECTLY ---
+# SOME DESCRIPTIVE TITLE.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2014-03-12 10:43+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"Preferred-Encodings: utf-8 latin1\n"
+
+msgid "participation:invitation_accepted"
+msgstr "Invitation accepted"
+
+msgid "participation:invitation_created"
+msgstr "Invitation created"
+
+msgid "participation:invitation_rejected"
+msgstr "Invitation rejected"
+
+msgid "participation:invitation_retracted"
+msgstr "Invitation retracted"
+
+msgid "participation:role_changed"
+msgstr "Role changed"
+
+msgid "participation:role_removed"
+msgstr "Participant removed"

--- a/ftw/participation/locales/en/LC_MESSAGES/ftw.participation.po
+++ b/ftw/participation/locales/en/LC_MESSAGES/ftw.participation.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-11-11 14:15+0000\n"
+"POT-Creation-Date: 2016-11-29 21:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -11,15 +11,19 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
 
+#: ./ftw/participation/activity/utils.py:8
+msgid " and "
+msgstr ""
+
 #: ./ftw/participation/browser/invitations.pt:68
 msgid "Accept"
 msgstr ""
 
-#: ./ftw/participation/browser/participants.py:62
+#: ./ftw/participation/browser/participants.py:67
 msgid "Changes saved."
 msgstr ""
 
-#: ./ftw/participation/browser/invite.py:125
+#: ./ftw/participation/browser/invite.py:127
 msgid "Enter at least one e-mail address."
 msgstr ""
 
@@ -51,11 +55,11 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: ./ftw/participation/browser/invite.py:122
+#: ./ftw/participation/browser/invite.py:124
 msgid "Select at least one user or enter at least one e-mail address"
 msgstr "Select at least one user or enter at least one e-mail address"
 
-#: ./ftw/participation/browser/invite.py:127
+#: ./ftw/participation/browser/invite.py:129
 msgid "Select at least one user."
 msgstr "Select at least one user"
 
@@ -75,9 +79,29 @@ msgstr "Hello ${inviter_name}"
 msgid "accepted_mail_text"
 msgstr ""
 
+#. Default: "${inviter} has invited ${mail} as ${roles}."
+#: ./ftw/participation/activity/renderer.py:31
+msgid "activity_invitation_created_body"
+msgstr ""
+
+#. Default: "${actor} has retracted the invitation for ${mail}."
+#: ./ftw/participation/activity/renderer.py:42
+msgid "activity_invitation_retracted_body"
+msgstr ""
+
+#. Default: "${actor} has removed the participant ${subject}."
+#: ./ftw/participation/activity/renderer.py:70
+msgid "activity_participant_removed_body"
+msgstr ""
+
+#. Default: "${actor} has changed the role of ${subject} from ${removed_roles} to ${added_roles}."
+#: ./ftw/participation/activity/renderer.py:57
+msgid "activity_role_changed_body"
+msgstr ""
+
 #. Default: "Cancel"
-#: ./ftw/participation/browser/changeroles.py:102
-#: ./ftw/participation/browser/invite.py:262
+#: ./ftw/participation/browser/changeroles.py:110
+#: ./ftw/participation/browser/invite.py:266
 #: ./ftw/participation/browser/participants_form.pt:83
 msgid "button_cancel"
 msgstr ""
@@ -88,43 +112,43 @@ msgid "button_delete_participants"
 msgstr ""
 
 #. Default: "Invite"
-#: ./ftw/participation/browser/invite.py:216
+#: ./ftw/participation/browser/invite.py:218
 msgid "button_invite"
 msgstr ""
 
 #. Default: "Save"
-#: ./ftw/participation/browser/changeroles.py:89
+#: ./ftw/participation/browser/changeroles.py:91
 msgid "button_save"
 msgstr ""
 
 #. Default: "At least one of the defined addresses are not valid."
-#: ./ftw/participation/browser/invite.py:99
+#: ./ftw/participation/browser/invite.py:101
 msgid "error_invalid_addresses"
 msgstr ""
 
 #. Default: "Could not find the invitation."
-#: ./ftw/participation/browser/accept.py:60
-#: ./ftw/participation/browser/retract.py:46
+#: ./ftw/participation/browser/accept.py:63
+#: ./ftw/participation/browser/retract.py:49
 msgid "error_invitation_not_found"
 msgstr ""
 
 #. Default: "Invitor could not be notified: he has no email address defined."
-#: ./ftw/participation/browser/accept.py:86
+#: ./ftw/participation/browser/accept.py:89
 msgid "error_inviter_email_missing"
 msgstr ""
 
 #. Default: "Please select a role"
-#: ./ftw/participation/browser/invite.py:162
+#: ./ftw/participation/browser/invite.py:164
 msgid "error_no_roles"
 msgstr ""
 
 #. Default: "The participation quota is reached, you cannot add any further participants."
-#: ./ftw/participation/browser/invite.py:135
+#: ./ftw/participation/browser/invite.py:137
 msgid "error_participation_quota_reached"
 msgstr ""
 
 #. Default: "You cannot invite so many participants any more. Can only add ${num} more participants."
-#: ./ftw/participation/browser/invite.py:139
+#: ./ftw/participation/browser/invite.py:141
 msgid "error_too_many_participants"
 msgstr "You have only ${num} invitations left."
 
@@ -157,27 +181,27 @@ msgid "headline_sent_invitations"
 msgstr ""
 
 #. Default: "Enter one e-mail address per line"
-#: ./ftw/participation/browser/invite.py:49
+#: ./ftw/participation/browser/invite.py:51
 msgid "help_addresses"
 msgstr "Enter one email address per line"
 
 #. Default: "Allow to invite participants by typing the e-mail address in the invitation form. It is recommended to enable registriation in plone security"
-#: ./ftw/participation/interfaces.py:26
+#: ./ftw/participation/interfaces.py:28
 msgid "help_allow_invite_email"
 msgstr ""
 
 #. Default: "Allow to search users from PAS in invitation form."
-#: ./ftw/participation/interfaces.py:18
+#: ./ftw/participation/interfaces.py:20
 msgid "help_allow_invite_users"
 msgstr ""
 
 #. Default: "Enter a comment which will be contained in the invitaiton E-Mail"
-#: ./ftw/participation/browser/invite.py:61
+#: ./ftw/participation/browser/invite.py:63
 msgid "help_comment"
 msgstr "The comment will be included in the invitation email"
 
 #. Default: "Allow to pass multiple roles to a invited user."
-#: ./ftw/participation/interfaces.py:35
+#: ./ftw/participation/interfaces.py:37
 msgid "help_multiple_roles"
 msgstr "When inviting, grant users more than one role."
 
@@ -186,27 +210,27 @@ msgid "help_participation_quota_limit"
 msgstr ""
 
 #. Default: "Select users to invite."
-#: ./ftw/participation/browser/invite.py:41
+#: ./ftw/participation/browser/invite.py:43
 msgid "help_users"
 msgstr ""
 
 #. Default: "You have accepted the invitation."
-#: ./ftw/participation/browser/accept.py:33
+#: ./ftw/participation/browser/accept.py:36
 msgid "info_invitation_accepted"
 msgstr ""
 
 #. Default: "You have rejected the invitation."
-#: ./ftw/participation/browser/reject.py:26
+#: ./ftw/participation/browser/reject.py:29
 msgid "info_invitation_rejected"
 msgstr ""
 
 #. Default: "You have retracted the invitation."
-#: ./ftw/participation/browser/retract.py:20
+#: ./ftw/participation/browser/retract.py:23
 msgid "info_invitation_retracted"
 msgstr ""
 
 #. Default: "The invitation mails were sent to ${emails}."
-#: ./ftw/participation/browser/invite.py:256
+#: ./ftw/participation/browser/invite.py:260
 msgid "info_invitations_sent"
 msgstr ""
 
@@ -255,17 +279,17 @@ msgid "label_accepted"
 msgstr ""
 
 #. Default: "E-Mail Addresses"
-#: ./ftw/participation/browser/invite.py:48
+#: ./ftw/participation/browser/invite.py:50
 msgid "label_addresses"
 msgstr ""
 
 #. Default: "Allow to invite participants by email"
-#: ./ftw/participation/interfaces.py:24
+#: ./ftw/participation/interfaces.py:26
 msgid "label_allow_invite_email"
 msgstr ""
 
 #. Default: "Allow to invite users"
-#: ./ftw/participation/interfaces.py:16
+#: ./ftw/participation/interfaces.py:18
 msgid "label_allow_invite_users"
 msgstr ""
 
@@ -275,17 +299,17 @@ msgid "label_change"
 msgstr ""
 
 #. Default: "Change roles"
-#: ./ftw/participation/browser/changeroles.py:50
+#: ./ftw/participation/browser/changeroles.py:52
 msgid "label_changerole_form"
 msgstr ""
 
 #. Default: "Comment"
-#: ./ftw/participation/browser/invite.py:60
+#: ./ftw/participation/browser/invite.py:62
 msgid "label_comment"
 msgstr ""
 
 #. Default: "Invite Participants"
-#: ./ftw/participation/browser/invite.py:171
+#: ./ftw/participation/browser/invite.py:173
 msgid "label_invite_participants"
 msgstr "Invite participants"
 
@@ -300,7 +324,7 @@ msgid "label_local_roles"
 msgstr ""
 
 #. Default: "Allow to give multiple roles"
-#: ./ftw/participation/interfaces.py:33
+#: ./ftw/participation/interfaces.py:35
 msgid "label_multiple_roles"
 msgstr "Enable selecting more than one role in invitation"
 
@@ -315,8 +339,8 @@ msgid "label_pending"
 msgstr ""
 
 #. Default: "Roles"
-#: ./ftw/participation/browser/changeroles.py:40
-#: ./ftw/participation/browser/invite.py:54
+#: ./ftw/participation/browser/changeroles.py:42
+#: ./ftw/participation/browser/invite.py:56
 msgid "label_roles"
 msgstr ""
 
@@ -331,7 +355,7 @@ msgid "label_user"
 msgstr ""
 
 #. Default: "Users"
-#: ./ftw/participation/browser/invite.py:40
+#: ./ftw/participation/browser/invite.py:42
 msgid "label_users"
 msgstr ""
 
@@ -351,22 +375,22 @@ msgid "link_reject_invitation"
 msgstr "No, I reject the invitation"
 
 #. Default: "The Invitation to participate in ${title} was accepted by ${user}"
-#: ./ftw/participation/browser/accept.py:154
+#: ./ftw/participation/browser/accept.py:157
 msgid "mail_invitation_accepted_subject"
 msgstr ""
 
 #. Default: "The Invitation to participate in ${title} was rejected by ${user}"
-#: ./ftw/participation/browser/reject.py:58
+#: ./ftw/participation/browser/reject.py:61
 msgid "mail_invitation_rejected_subject"
 msgstr ""
 
 #. Default: "Invitation for paticipating in ${title}"
-#: ./ftw/participation/browser/invite.py:329
+#: ./ftw/participation/browser/invite.py:333
 msgid "mail_invitation_subject"
 msgstr ""
 
 #. Default: "Changed roles"
-#: ./ftw/participation/browser/changeroles.py:120
+#: ./ftw/participation/browser/changeroles.py:128
 msgid "message_roles_changes"
 msgstr ""
 
@@ -388,7 +412,7 @@ msgid "text_infos_participants"
 msgstr ""
 
 #. Default: "Use this form to invide new user"
-#: ./ftw/participation/browser/invite.py:173
+#: ./ftw/participation/browser/invite.py:175
 msgid "text_invite_new"
 msgstr "Use this form to invite new users"
 

--- a/ftw/participation/locales/fr/LC_MESSAGES/ftw.participation.po
+++ b/ftw/participation/locales/fr/LC_MESSAGES/ftw.participation.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-11-11 14:15+0000\n"
+"POT-Creation-Date: 2016-11-29 21:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -11,15 +11,19 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
 
+#: ./ftw/participation/activity/utils.py:8
+msgid " and "
+msgstr " et "
+
 #: ./ftw/participation/browser/invitations.pt:68
 msgid "Accept"
 msgstr "Accepté"
 
-#: ./ftw/participation/browser/participants.py:62
+#: ./ftw/participation/browser/participants.py:67
 msgid "Changes saved."
 msgstr "Les changements sont sauvegardés"
 
-#: ./ftw/participation/browser/invite.py:125
+#: ./ftw/participation/browser/invite.py:127
 msgid "Enter at least one e-mail address."
 msgstr "Indiquer au moins une adresse courriel"
 
@@ -51,11 +55,11 @@ msgstr ""
 msgid "Retract"
 msgstr "Annuler"
 
-#: ./ftw/participation/browser/invite.py:122
+#: ./ftw/participation/browser/invite.py:124
 msgid "Select at least one user or enter at least one e-mail address"
 msgstr "Choisissez ou rentrer au moins une personne ou une adresse courriel"
 
-#: ./ftw/participation/browser/invite.py:127
+#: ./ftw/participation/browser/invite.py:129
 msgid "Select at least one user."
 msgstr "Choisissez au moins un utilisateur"
 
@@ -75,9 +79,29 @@ msgstr "Bonjour, ${inviter_name}"
 msgid "accepted_mail_text"
 msgstr "Votre invitation a participer à ${context_title} a été acceptée par l'utilisateur ${invited_name} (${invited_email})."
 
+#. Default: "${inviter} has invited ${mail} as ${roles}."
+#: ./ftw/participation/activity/renderer.py:31
+msgid "activity_invitation_created_body"
+msgstr ""
+
+#. Default: "${actor} has retracted the invitation for ${mail}."
+#: ./ftw/participation/activity/renderer.py:42
+msgid "activity_invitation_retracted_body"
+msgstr ""
+
+#. Default: "${actor} has removed the participant ${subject}."
+#: ./ftw/participation/activity/renderer.py:70
+msgid "activity_participant_removed_body"
+msgstr ""
+
+#. Default: "${actor} has changed the role of ${subject} from ${removed_roles} to ${added_roles}."
+#: ./ftw/participation/activity/renderer.py:57
+msgid "activity_role_changed_body"
+msgstr ""
+
 #. Default: "Cancel"
-#: ./ftw/participation/browser/changeroles.py:102
-#: ./ftw/participation/browser/invite.py:262
+#: ./ftw/participation/browser/changeroles.py:110
+#: ./ftw/participation/browser/invite.py:266
 #: ./ftw/participation/browser/participants_form.pt:83
 msgid "button_cancel"
 msgstr "Annuler"
@@ -88,43 +112,43 @@ msgid "button_delete_participants"
 msgstr "Supprimer des participants"
 
 #. Default: "Invite"
-#: ./ftw/participation/browser/invite.py:216
+#: ./ftw/participation/browser/invite.py:218
 msgid "button_invite"
 msgstr "Inviter"
 
 #. Default: "Save"
-#: ./ftw/participation/browser/changeroles.py:89
+#: ./ftw/participation/browser/changeroles.py:91
 msgid "button_save"
 msgstr "Enregistrer"
 
 #. Default: "At least one of the defined addresses are not valid."
-#: ./ftw/participation/browser/invite.py:99
+#: ./ftw/participation/browser/invite.py:101
 msgid "error_invalid_addresses"
 msgstr "Au moins une des adresses soumises est incorrecte"
 
 #. Default: "Could not find the invitation."
-#: ./ftw/participation/browser/accept.py:60
-#: ./ftw/participation/browser/retract.py:46
+#: ./ftw/participation/browser/accept.py:63
+#: ./ftw/participation/browser/retract.py:49
 msgid "error_invitation_not_found"
 msgstr "L'invitation est introuvable"
 
 #. Default: "Invitor could not be notified: he has no email address defined."
-#: ./ftw/participation/browser/accept.py:86
+#: ./ftw/participation/browser/accept.py:89
 msgid "error_inviter_email_missing"
 msgstr "La personne invitante n’a pas pu être contactée: Elle n’a pas défini une adresse courriel."
 
 #. Default: "Please select a role"
-#: ./ftw/participation/browser/invite.py:162
+#: ./ftw/participation/browser/invite.py:164
 msgid "error_no_roles"
 msgstr ""
 
 #. Default: "The participation quota is reached, you cannot add any further participants."
-#: ./ftw/participation/browser/invite.py:135
+#: ./ftw/participation/browser/invite.py:137
 msgid "error_participation_quota_reached"
 msgstr "Le nombre maximal de participants est atteint, vous ne pouvez pas ajouter d'autres participants."
 
 #. Default: "You cannot invite so many participants any more. Can only add ${num} more participants."
-#: ./ftw/participation/browser/invite.py:139
+#: ./ftw/participation/browser/invite.py:141
 msgid "error_too_many_participants"
 msgstr "Vous ne pouvez pas inviter autant de participants. Vous pouvez envoyer le maximum de ${num} invitations."
 
@@ -157,27 +181,27 @@ msgid "headline_sent_invitations"
 msgstr "Invitations envoyées"
 
 #. Default: "Enter one e-mail address per line"
-#: ./ftw/participation/browser/invite.py:49
+#: ./ftw/participation/browser/invite.py:51
 msgid "help_addresses"
 msgstr "Pour inviter de nouvelles personnes, saisissez une adresse courriel par champ"
 
 #. Default: "Allow to invite participants by typing the e-mail address in the invitation form. It is recommended to enable registriation in plone security"
-#: ./ftw/participation/interfaces.py:26
+#: ./ftw/participation/interfaces.py:28
 msgid "help_allow_invite_email"
 msgstr "Des personnes non inscrites peuvent être invitées par adresse courriel."
 
 #. Default: "Allow to search users from PAS in invitation form."
-#: ./ftw/participation/interfaces.py:18
+#: ./ftw/participation/interfaces.py:20
 msgid "help_allow_invite_users"
 msgstr "Des utilisateurs existants peuvent être recherchés et invités."
 
 #. Default: "Enter a comment which will be contained in the invitaiton E-Mail"
-#: ./ftw/participation/browser/invite.py:61
+#: ./ftw/participation/browser/invite.py:63
 msgid "help_comment"
 msgstr "Ce commentaire va être inséré dans le courriel d'invitation."
 
 #. Default: "Allow to pass multiple roles to a invited user."
-#: ./ftw/participation/interfaces.py:35
+#: ./ftw/participation/interfaces.py:37
 msgid "help_multiple_roles"
 msgstr ""
 
@@ -186,27 +210,27 @@ msgid "help_participation_quota_limit"
 msgstr "Avec l'aide des limites de quota, vous pouvez définir le nombre maximal de participants"
 
 #. Default: "Select users to invite."
-#: ./ftw/participation/browser/invite.py:41
+#: ./ftw/participation/browser/invite.py:43
 msgid "help_users"
 msgstr "Sélectionnez une ou plusieurs personnes. Vous pouvez chercher par l'adresse courriel ou nom et prénom"
 
 #. Default: "You have accepted the invitation."
-#: ./ftw/participation/browser/accept.py:33
+#: ./ftw/participation/browser/accept.py:36
 msgid "info_invitation_accepted"
 msgstr "Vous avez accepté l'invitation"
 
 #. Default: "You have rejected the invitation."
-#: ./ftw/participation/browser/reject.py:26
+#: ./ftw/participation/browser/reject.py:29
 msgid "info_invitation_rejected"
 msgstr "Vous avez refusé l'invitation"
 
 #. Default: "You have retracted the invitation."
-#: ./ftw/participation/browser/retract.py:20
+#: ./ftw/participation/browser/retract.py:23
 msgid "info_invitation_retracted"
 msgstr "Vous avez annulé l'invitation"
 
 #. Default: "The invitation mails were sent to ${emails}."
-#: ./ftw/participation/browser/invite.py:256
+#: ./ftw/participation/browser/invite.py:260
 msgid "info_invitations_sent"
 msgstr "L'invitation a été envoyée par courriel à ${emails}"
 
@@ -255,17 +279,17 @@ msgid "label_accepted"
 msgstr ""
 
 #. Default: "E-Mail Addresses"
-#: ./ftw/participation/browser/invite.py:48
+#: ./ftw/participation/browser/invite.py:50
 msgid "label_addresses"
 msgstr "Adresses courriel"
 
 #. Default: "Allow to invite participants by email"
-#: ./ftw/participation/interfaces.py:24
+#: ./ftw/participation/interfaces.py:26
 msgid "label_allow_invite_email"
 msgstr "Participer des utilisateurs externes"
 
 #. Default: "Allow to invite users"
-#: ./ftw/participation/interfaces.py:16
+#: ./ftw/participation/interfaces.py:18
 msgid "label_allow_invite_users"
 msgstr "Participer des utilisateurs existants"
 
@@ -275,17 +299,17 @@ msgid "label_change"
 msgstr "modifier"
 
 #. Default: "Change roles"
-#: ./ftw/participation/browser/changeroles.py:50
+#: ./ftw/participation/browser/changeroles.py:52
 msgid "label_changerole_form"
 msgstr "Modifier Autorisations"
 
 #. Default: "Comment"
-#: ./ftw/participation/browser/invite.py:60
+#: ./ftw/participation/browser/invite.py:62
 msgid "label_comment"
 msgstr "Commentaire"
 
 #. Default: "Invite Participants"
-#: ./ftw/participation/browser/invite.py:171
+#: ./ftw/participation/browser/invite.py:173
 msgid "label_invite_participants"
 msgstr "Inviter des participants"
 
@@ -300,7 +324,7 @@ msgid "label_local_roles"
 msgstr ""
 
 #. Default: "Allow to give multiple roles"
-#: ./ftw/participation/interfaces.py:33
+#: ./ftw/participation/interfaces.py:35
 msgid "label_multiple_roles"
 msgstr ""
 
@@ -315,8 +339,8 @@ msgid "label_pending"
 msgstr ""
 
 #. Default: "Roles"
-#: ./ftw/participation/browser/changeroles.py:40
-#: ./ftw/participation/browser/invite.py:54
+#: ./ftw/participation/browser/changeroles.py:42
+#: ./ftw/participation/browser/invite.py:56
 msgid "label_roles"
 msgstr "Autorisations"
 
@@ -331,7 +355,7 @@ msgid "label_user"
 msgstr ""
 
 #. Default: "Users"
-#: ./ftw/participation/browser/invite.py:40
+#: ./ftw/participation/browser/invite.py:42
 msgid "label_users"
 msgstr "Utilisateur"
 
@@ -351,22 +375,22 @@ msgid "link_reject_invitation"
 msgstr "Non, je ne veux pas y participer"
 
 #. Default: "The Invitation to participate in ${title} was accepted by ${user}"
-#: ./ftw/participation/browser/accept.py:154
+#: ./ftw/participation/browser/accept.py:157
 msgid "mail_invitation_accepted_subject"
 msgstr "L'invitation pour ${title] a été acceptée par ${user}"
 
 #. Default: "The Invitation to participate in ${title} was rejected by ${user}"
-#: ./ftw/participation/browser/reject.py:58
+#: ./ftw/participation/browser/reject.py:61
 msgid "mail_invitation_rejected_subject"
 msgstr "L'invitation pour ${title] a été refusée par ${user}"
 
 #. Default: "Invitation for paticipating in ${title}"
-#: ./ftw/participation/browser/invite.py:329
+#: ./ftw/participation/browser/invite.py:333
 msgid "mail_invitation_subject"
 msgstr "Invitations pour une participation à ${title}"
 
 #. Default: "Changed roles"
-#: ./ftw/participation/browser/changeroles.py:120
+#: ./ftw/participation/browser/changeroles.py:128
 msgid "message_roles_changes"
 msgstr ""
 
@@ -388,7 +412,7 @@ msgid "text_infos_participants"
 msgstr ""
 
 #. Default: "Use this form to invide new user"
-#: ./ftw/participation/browser/invite.py:173
+#: ./ftw/participation/browser/invite.py:175
 msgid "text_invite_new"
 msgstr "Avec ce formulaire, vous pouvez inviter de nouvelles personnes. Après avoir cliqué sur \"Inviter\", les personnes sélectionnées reçevront un e-mail contenant l'invitation."
 
@@ -416,4 +440,3 @@ msgstr "Vous avez invité les utilisateurs suivants. Ils n'ont pas encore confir
 #: ./ftw/participation/browser/invitations.py:111
 msgid "warning_invitaiton_expired"
 msgstr "Votre invitation est expirée"
-

--- a/ftw/participation/locales/ftw.activity.pot
+++ b/ftw/participation/locales/ftw.activity.pot
@@ -1,0 +1,33 @@
+# --- PLEASE EDIT THE LINES BELOW CORRECTLY ---
+# SOME DESCRIPTIVE TITLE.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2014-03-12 10:43+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"Preferred-Encodings: utf-8 latin1\n"
+
+msgid "participation:invitation_created"
+msgstr ""
+
+msgid "participation:invitation_accepted"
+msgstr ""
+
+msgid "participation:invitation_rejected"
+msgstr ""
+
+msgid "participation:invitation_retracted"
+msgstr ""
+
+msgid "participation:role_changed"
+msgstr ""
+
+msgid "participation:role_removed"
+msgstr ""

--- a/ftw/participation/locales/ftw.participation.pot
+++ b/ftw/participation/locales/ftw.participation.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-11-11 14:15+0000\n"
+"POT-Creation-Date: 2016-11-29 21:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,15 +14,19 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
 
+#: ./ftw/participation/activity/utils.py:8
+msgid " and "
+msgstr ""
+
 #: ./ftw/participation/browser/invitations.pt:68
 msgid "Accept"
 msgstr ""
 
-#: ./ftw/participation/browser/participants.py:62
+#: ./ftw/participation/browser/participants.py:67
 msgid "Changes saved."
 msgstr ""
 
-#: ./ftw/participation/browser/invite.py:125
+#: ./ftw/participation/browser/invite.py:127
 msgid "Enter at least one e-mail address."
 msgstr ""
 
@@ -54,11 +58,11 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: ./ftw/participation/browser/invite.py:122
+#: ./ftw/participation/browser/invite.py:124
 msgid "Select at least one user or enter at least one e-mail address"
 msgstr ""
 
-#: ./ftw/participation/browser/invite.py:127
+#: ./ftw/participation/browser/invite.py:129
 msgid "Select at least one user."
 msgstr ""
 
@@ -78,9 +82,29 @@ msgstr ""
 msgid "accepted_mail_text"
 msgstr ""
 
+#. Default: "${inviter} has invited ${mail} as ${roles}."
+#: ./ftw/participation/activity/renderer.py:31
+msgid "activity_invitation_created_body"
+msgstr ""
+
+#. Default: "${actor} has retracted the invitation for ${mail}."
+#: ./ftw/participation/activity/renderer.py:42
+msgid "activity_invitation_retracted_body"
+msgstr ""
+
+#. Default: "${actor} has removed the participant ${subject}."
+#: ./ftw/participation/activity/renderer.py:70
+msgid "activity_participant_removed_body"
+msgstr ""
+
+#. Default: "${actor} has changed the role of ${subject} from ${removed_roles} to ${added_roles}."
+#: ./ftw/participation/activity/renderer.py:57
+msgid "activity_role_changed_body"
+msgstr ""
+
 #. Default: "Cancel"
-#: ./ftw/participation/browser/changeroles.py:102
-#: ./ftw/participation/browser/invite.py:262
+#: ./ftw/participation/browser/changeroles.py:110
+#: ./ftw/participation/browser/invite.py:266
 #: ./ftw/participation/browser/participants_form.pt:83
 msgid "button_cancel"
 msgstr ""
@@ -91,43 +115,43 @@ msgid "button_delete_participants"
 msgstr ""
 
 #. Default: "Invite"
-#: ./ftw/participation/browser/invite.py:216
+#: ./ftw/participation/browser/invite.py:218
 msgid "button_invite"
 msgstr ""
 
 #. Default: "Save"
-#: ./ftw/participation/browser/changeroles.py:89
+#: ./ftw/participation/browser/changeroles.py:91
 msgid "button_save"
 msgstr ""
 
 #. Default: "At least one of the defined addresses are not valid."
-#: ./ftw/participation/browser/invite.py:99
+#: ./ftw/participation/browser/invite.py:101
 msgid "error_invalid_addresses"
 msgstr ""
 
 #. Default: "Could not find the invitation."
-#: ./ftw/participation/browser/accept.py:60
-#: ./ftw/participation/browser/retract.py:46
+#: ./ftw/participation/browser/accept.py:63
+#: ./ftw/participation/browser/retract.py:49
 msgid "error_invitation_not_found"
 msgstr ""
 
 #. Default: "Invitor could not be notified: he has no email address defined."
-#: ./ftw/participation/browser/accept.py:86
+#: ./ftw/participation/browser/accept.py:89
 msgid "error_inviter_email_missing"
 msgstr ""
 
 #. Default: "Please select a role"
-#: ./ftw/participation/browser/invite.py:162
+#: ./ftw/participation/browser/invite.py:164
 msgid "error_no_roles"
 msgstr ""
 
 #. Default: "The participation quota is reached, you cannot add any further participants."
-#: ./ftw/participation/browser/invite.py:135
+#: ./ftw/participation/browser/invite.py:137
 msgid "error_participation_quota_reached"
 msgstr ""
 
 #. Default: "You cannot invite so many participants any more. Can only add ${num} more participants."
-#: ./ftw/participation/browser/invite.py:139
+#: ./ftw/participation/browser/invite.py:141
 msgid "error_too_many_participants"
 msgstr ""
 
@@ -160,27 +184,27 @@ msgid "headline_sent_invitations"
 msgstr ""
 
 #. Default: "Enter one e-mail address per line"
-#: ./ftw/participation/browser/invite.py:49
+#: ./ftw/participation/browser/invite.py:51
 msgid "help_addresses"
 msgstr ""
 
 #. Default: "Allow to invite participants by typing the e-mail address in the invitation form. It is recommended to enable registriation in plone security"
-#: ./ftw/participation/interfaces.py:26
+#: ./ftw/participation/interfaces.py:28
 msgid "help_allow_invite_email"
 msgstr ""
 
 #. Default: "Allow to search users from PAS in invitation form."
-#: ./ftw/participation/interfaces.py:18
+#: ./ftw/participation/interfaces.py:20
 msgid "help_allow_invite_users"
 msgstr ""
 
 #. Default: "Enter a comment which will be contained in the invitaiton E-Mail"
-#: ./ftw/participation/browser/invite.py:61
+#: ./ftw/participation/browser/invite.py:63
 msgid "help_comment"
 msgstr ""
 
 #. Default: "Allow to pass multiple roles to a invited user."
-#: ./ftw/participation/interfaces.py:35
+#: ./ftw/participation/interfaces.py:37
 msgid "help_multiple_roles"
 msgstr ""
 
@@ -189,27 +213,27 @@ msgid "help_participation_quota_limit"
 msgstr ""
 
 #. Default: "Select users to invite."
-#: ./ftw/participation/browser/invite.py:41
+#: ./ftw/participation/browser/invite.py:43
 msgid "help_users"
 msgstr ""
 
 #. Default: "You have accepted the invitation."
-#: ./ftw/participation/browser/accept.py:33
+#: ./ftw/participation/browser/accept.py:36
 msgid "info_invitation_accepted"
 msgstr ""
 
 #. Default: "You have rejected the invitation."
-#: ./ftw/participation/browser/reject.py:26
+#: ./ftw/participation/browser/reject.py:29
 msgid "info_invitation_rejected"
 msgstr ""
 
 #. Default: "You have retracted the invitation."
-#: ./ftw/participation/browser/retract.py:20
+#: ./ftw/participation/browser/retract.py:23
 msgid "info_invitation_retracted"
 msgstr ""
 
 #. Default: "The invitation mails were sent to ${emails}."
-#: ./ftw/participation/browser/invite.py:256
+#: ./ftw/participation/browser/invite.py:260
 msgid "info_invitations_sent"
 msgstr ""
 
@@ -258,17 +282,17 @@ msgid "label_accepted"
 msgstr ""
 
 #. Default: "E-Mail Addresses"
-#: ./ftw/participation/browser/invite.py:48
+#: ./ftw/participation/browser/invite.py:50
 msgid "label_addresses"
 msgstr ""
 
 #. Default: "Allow to invite participants by email"
-#: ./ftw/participation/interfaces.py:24
+#: ./ftw/participation/interfaces.py:26
 msgid "label_allow_invite_email"
 msgstr ""
 
 #. Default: "Allow to invite users"
-#: ./ftw/participation/interfaces.py:16
+#: ./ftw/participation/interfaces.py:18
 msgid "label_allow_invite_users"
 msgstr ""
 
@@ -278,17 +302,17 @@ msgid "label_change"
 msgstr ""
 
 #. Default: "Change roles"
-#: ./ftw/participation/browser/changeroles.py:50
+#: ./ftw/participation/browser/changeroles.py:52
 msgid "label_changerole_form"
 msgstr ""
 
 #. Default: "Comment"
-#: ./ftw/participation/browser/invite.py:60
+#: ./ftw/participation/browser/invite.py:62
 msgid "label_comment"
 msgstr ""
 
 #. Default: "Invite Participants"
-#: ./ftw/participation/browser/invite.py:171
+#: ./ftw/participation/browser/invite.py:173
 msgid "label_invite_participants"
 msgstr ""
 
@@ -303,7 +327,7 @@ msgid "label_local_roles"
 msgstr ""
 
 #. Default: "Allow to give multiple roles"
-#: ./ftw/participation/interfaces.py:33
+#: ./ftw/participation/interfaces.py:35
 msgid "label_multiple_roles"
 msgstr ""
 
@@ -318,8 +342,8 @@ msgid "label_pending"
 msgstr ""
 
 #. Default: "Roles"
-#: ./ftw/participation/browser/changeroles.py:40
-#: ./ftw/participation/browser/invite.py:54
+#: ./ftw/participation/browser/changeroles.py:42
+#: ./ftw/participation/browser/invite.py:56
 msgid "label_roles"
 msgstr ""
 
@@ -334,7 +358,7 @@ msgid "label_user"
 msgstr ""
 
 #. Default: "Users"
-#: ./ftw/participation/browser/invite.py:40
+#: ./ftw/participation/browser/invite.py:42
 msgid "label_users"
 msgstr ""
 
@@ -354,22 +378,22 @@ msgid "link_reject_invitation"
 msgstr ""
 
 #. Default: "The Invitation to participate in ${title} was accepted by ${user}"
-#: ./ftw/participation/browser/accept.py:154
+#: ./ftw/participation/browser/accept.py:157
 msgid "mail_invitation_accepted_subject"
 msgstr ""
 
 #. Default: "The Invitation to participate in ${title} was rejected by ${user}"
-#: ./ftw/participation/browser/reject.py:58
+#: ./ftw/participation/browser/reject.py:61
 msgid "mail_invitation_rejected_subject"
 msgstr ""
 
 #. Default: "Invitation for paticipating in ${title}"
-#: ./ftw/participation/browser/invite.py:329
+#: ./ftw/participation/browser/invite.py:333
 msgid "mail_invitation_subject"
 msgstr ""
 
 #. Default: "Changed roles"
-#: ./ftw/participation/browser/changeroles.py:120
+#: ./ftw/participation/browser/changeroles.py:128
 msgid "message_roles_changes"
 msgstr ""
 
@@ -391,7 +415,7 @@ msgid "text_infos_participants"
 msgstr ""
 
 #. Default: "Use this form to invide new user"
-#: ./ftw/participation/browser/invite.py:173
+#: ./ftw/participation/browser/invite.py:175
 msgid "text_invite_new"
 msgstr ""
 

--- a/ftw/participation/tests/test_activity.py
+++ b/ftw/participation/tests/test_activity.py
@@ -1,0 +1,231 @@
+from ftw.activity.tests.helpers import get_soup_activities
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.participation.interfaces import IParticipationSupport
+from ftw.participation.invitation import Invitation
+from ftw.participation.tests import FunctionalTestCase
+from ftw.testbrowser import browsing
+import transaction
+
+
+
+class TestActivity(FunctionalTestCase):
+
+    @browsing
+    def test_invitation_created_activity(self, browser):
+        self.grant('Manager')
+        folder = create(Builder('folder').providing(IParticipationSupport))
+        browser.login().open(folder, view='invite_participants')
+        browser.fill({'E-Mail Addresses': 'hugo@boss.com',
+                      'Roles': ['Contributor'],
+                      'Comment': u'Hi th\xf6re'})
+        browser.find('Invite').click()
+
+        self.maxDiff = None
+        self.assertEquals(
+            [
+                {'action': 'added',
+                 'actor': 'test_user_1_',
+                 'path': '/plone/folder'},
+
+                {'action': 'participation:invitation_created',
+                 'actor': 'test_user_1_',
+                 'path': '/plone/folder',
+                 'invitation:inviter': u'test_user_1_',
+                 'invitation:email': u'hugo@boss.com',
+                 'invitation:roles': (u'Contributor',),
+                 'invitation:comment': u'Hi th\xf6re',
+                },
+            ],
+
+            get_soup_activities(('path',
+                                 'action',
+                                 'actor',
+                                 'invitation:inviter',
+                                 'invitation:email',
+                                 'invitation:roles',
+                                 'invitation:comment')))
+
+    @browsing
+    def test_invitation_accepted_event(self, browser):
+        self.grant('Manager')
+        folder = create(Builder('folder').providing(IParticipationSupport))
+        inviter = create(Builder('user').named('John', 'Doe'))
+        user = create(Builder('user').named('Hugo', 'Boss'))
+        Invitation(target=folder,
+                   email=user.getProperty('email'),
+                   inviter=inviter.getId(),
+                   roles=['Reader'])
+        transaction.commit()
+
+        browser.login(user).open(view='invitations')
+        browser.click_on("Yes, I'd like to participate")
+
+        self.maxDiff = None
+        self.assertEquals(
+            [
+                {'action': 'added',
+                 'actor': 'test_user_1_',
+                 'path': '/plone/folder'},
+
+                {'action': 'participation:invitation_accepted',
+                 'actor': 'hugo.boss',
+                 'path': '/plone/folder',
+                 'invitation:inviter': 'john.doe',
+                 'invitation:email': 'hugo@boss.com',
+                 'invitation:roles': ('Reader',),
+                },
+            ],
+
+            get_soup_activities(('path',
+                                 'action',
+                                 'actor',
+                                 'invitation:inviter',
+                                 'invitation:email',
+                                 'invitation:roles',)))
+
+    @browsing
+    def test_invitation_rejected_event(self, browser):
+        self.grant('Manager')
+        folder = create(Builder('folder').providing(IParticipationSupport))
+        inviter = create(Builder('user').named('John', 'Doe'))
+        user = create(Builder('user').named('Hugo', 'Boss'))
+        Invitation(target=folder,
+                   email=user.getProperty('email'),
+                   inviter=inviter.getId(),
+                   roles=['Reader'])
+        transaction.commit()
+
+        browser.login(user).open(view='invitations')
+        browser.click_on("No, I reject the invitation")
+
+        self.maxDiff = None
+        self.assertEquals(
+            [
+                {'action': 'added',
+                 'actor': 'test_user_1_',
+                 'path': '/plone/folder'},
+
+                {'action': 'participation:invitation_rejected',
+                 'actor': 'hugo.boss',
+                 'path': '/plone/folder',
+                 'invitation:inviter': 'john.doe',
+                 'invitation:email': 'hugo@boss.com',
+                 'invitation:roles': ('Reader',),
+                },
+            ],
+
+            get_soup_activities(('path',
+                                 'action',
+                                 'actor',
+                                 'invitation:inviter',
+                                 'invitation:email',
+                                 'invitation:roles',)))
+
+    @browsing
+    def test_invitation_retracted_event(self, browser):
+        self.grant('Manager')
+        folder = create(Builder('folder').providing(IParticipationSupport))
+        inviter = create(Builder('user').named('John', 'Doe'))
+        invitation = Invitation(target=folder,
+                                email='foo@bar.com',
+                                inviter=inviter.getId(),
+                                roles=['Reader'])
+        transaction.commit()
+
+        browser.login(inviter).open(view='invitations')
+        browser.fill({'sent_invitations:list': invitation.iid})
+        browser.click_on('Retract')
+
+        self.maxDiff = None
+        self.assertEquals(
+            [
+                {'action': 'added',
+                 'actor': 'test_user_1_',
+                 'path': '/plone/folder'},
+
+                {'action': 'participation:invitation_retracted',
+                 'actor': 'john.doe',
+                 'path': '/plone/folder',
+                 'invitation:inviter': 'john.doe',
+                 'invitation:email': 'foo@bar.com',
+                 'invitation:roles': ('Reader',),
+                },
+            ],
+
+            get_soup_activities(('path',
+                                 'action',
+                                 'actor',
+                                 'invitation:inviter',
+                                 'invitation:email',
+                                 'invitation:roles',)))
+
+    @browsing
+    def test_roles_changed_event(self, browser):
+        self.grant('Manager')
+        folder = create(Builder('folder').providing(IParticipationSupport))
+
+        create(Builder('user').named('John', 'Doe')
+               .with_roles('Editor', on=folder))
+
+        browser.login().open(folder, view='participants')
+        browser.click_on('change')
+        # Only Editor and Contributor are selectable
+        browser.fill({'Roles': ['Contributor']}).submit()
+
+        self.maxDiff = None
+        self.assertEquals(
+            [
+                {'action': 'added',
+                 'actor': 'test_user_1_',
+                 'path': '/plone/folder'},
+
+                {'action': 'participation:role_changed',
+                 'actor': 'test_user_1_',
+                 'path': '/plone/folder',
+                 'roles:userid': 'john.doe',
+                 'roles:old': ('Editor',),
+                 'roles:removed': ('Editor',),
+                 'roles:new': ('Contributor',),
+                 'roles:added': ('Contributor',),
+                },
+            ],
+
+            get_soup_activities(('path',
+                                 'action',
+                                 'actor',
+                                 'roles:userid',
+                                 'roles:old',
+                                 'roles:removed',
+                                 'roles:new',
+                                 'roles:added')))
+
+    @browsing
+    def test_local_role_removed(self, browser):
+        self.grant('Manager')
+        folder = create(Builder('folder').providing(IParticipationSupport))
+        user = create(Builder('user').named('John', 'Doe')
+                      .with_roles('Editor', on=folder))
+
+        browser.login().open(folder, view='participants')
+        browser.fill({'userids:list': [user.getId()]}) \
+               .find('Delete Participants').click()
+
+        self.maxDiff = None
+        self.assertEquals(
+            [
+                {'action': 'added',
+                 'actor': 'test_user_1_',
+                 'path': '/plone/folder'},
+
+                {'action': 'participation:role_removed',
+                 'actor': 'test_user_1_',
+                 'path': '/plone/folder',
+                 'roles:userid': 'john.doe',
+                },
+            ],
+
+            get_soup_activities(('path',
+                                 'action',
+                                 'actor',
+                                 'roles:userid')))

--- a/ftw/participation/tests/test_activity_utils.py
+++ b/ftw/participation/tests/test_activity_utils.py
@@ -1,0 +1,26 @@
+from ftw.participation.activity.utils import translate_and_join_roles
+from ftw.participation.tests import FunctionalTestCase
+
+
+class TestInvitationRenderer(FunctionalTestCase):
+
+    def test_translate_and_join_roles__1_role(self):
+        self.assertEquals(
+            'Can add',
+            translate_and_join_roles(('Contributor',), None))
+
+    def test_translate_and_join_roles__2_roles(self):
+        self.assertEquals(
+            'Can add and Can view',
+            translate_and_join_roles(('Reader', 'Contributor'), None))
+
+    def test_translate_and_join_roles__3_roles(self):
+        self.assertEquals(
+            'Can add, Can edit and Can view',
+            translate_and_join_roles(('Reader', 'Editor', 'Contributor'), None))
+
+    def test_translate_and_join_roles__4_roles(self):
+        self.assertEquals(
+            'Can add, Can edit and Can view',
+            translate_and_join_roles(
+                ('Reader', 'Editor', 'Contributor', 'Manager'), None))

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(name='ftw.participation',
 
       classifiers=[
         'Framework :: Plone',
-        'Framework :: Plone :: 4.2',
         'Framework :: Plone :: 4.3',
         'Programming Language :: Python',
         'Topic :: Software Development :: Libraries :: Python Modules',

--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,22 @@ tests_require = (
     'zope.testing',
     'plone.app.testing',
     'zope.globalrequest', # Because of TinyMCE
+    'ftw.activity > 2',
     'ftw.builder',
     'ftw.testbrowser',
     'ftw.testing',
     'ftw.builder',
     'ftw.tabbedview',
     )
+
+
+extras_require = {
+    'tests': tests_require,
+    'activity': [
+        'ftw.activity > 2',
+    ]
+}
+
 
 setup(name='ftw.participation',
       version=version,
@@ -58,7 +68,7 @@ setup(name='ftw.participation',
         ],
 
       tests_require=tests_require,
-      extras_require=dict(tests=tests_require),
+      extras_require=extras_require,
       entry_points='''
       # -*- Entry points: -*-
       [z3c.autoinclude.plugin]

--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
-    sources.cfg
-
-package-name = ftw.participation
-
-versions=versions
-


### PR DESCRIPTION
- Provide ftw.activity support with the extras `ftw.participation [activity]`
- Record activites on participation events:
  - invitation created
  - invitation accepted
  - invitation rejected
  - invitation retracted
  - role changed
  - participation removed
- Add custom activity renderer for participation activities, showing additional information, such as the subject or the changed roles.