### PR TITLE
Fix unicode errors in activity renderer.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix unicode errors in activity renderer. [jone]
 
 
 1.4.0 (2016-11-30)

--- a/ftw/participation/activity/renderer.py
+++ b/ftw/participation/activity/renderer.py
@@ -22,31 +22,32 @@ class InvitationRenderer(DefaultRenderer):
 
     def prepare_comment(self, activity):
         action = activity.attrs['action']
+        actor_info = activity.get_actor_info()
+        actor_fullname = actor_info.get('fullname').decode('utf-8')
 
         if action == 'participation:invitation_created':
-            actor_info = activity.get_actor_info()
+            actor_email = activity.attrs['invitation:email'].decode('utf-8')
             roles = translate_and_join_roles(
                 activity.attrs['invitation:roles'], self.request)
 
             return _(u'activity_invitation_created_body',
                      default=u'${inviter} has invited ${mail} as ${roles}.',
-                     mapping={'inviter': actor_info.get('fullname'),
-                              'mail': activity.attrs['invitation:email'],
+                     mapping={'inviter': actor_fullname,
+                              'mail': actor_email,
                               'roles': roles})
 
         if action == 'participation:invitation_retracted':
-            actor_info = activity.get_actor_info()
+            actor_email = activity.attrs['invitation:email'].decode('utf-8')
             roles = translate_and_join_roles(
                 activity.attrs['invitation:roles'], self.request)
 
             return _(u'activity_invitation_retracted_body',
                      default=u'${actor} has retracted the invitation'
                      u' for ${mail}.',
-                     mapping={'actor': actor_info.get('fullname'),
-                              'mail': activity.attrs['invitation:email']})
+                     mapping={'actor': actor_fullname,
+                              'mail': actor_email})
 
         if action == 'participation:role_changed':
-            actor_info = activity.get_actor_info()
             subject_fullname = self.get_fullname_of(
                 activity.attrs['roles:userid'])
             removed_roles = translate_and_join_roles(
@@ -57,20 +58,19 @@ class InvitationRenderer(DefaultRenderer):
             return _(u'activity_role_changed_body',
                      default=u'${actor} has changed the role of ${subject}'
                      u' from ${removed_roles} to ${added_roles}.',
-                     mapping={'actor': actor_info.get('fullname'),
+                     mapping={'actor': actor_fullname,
                               'subject': subject_fullname,
                               'removed_roles': removed_roles,
                               'added_roles': added_roles})
 
         if action == 'participation:role_removed':
-            actor_info = activity.get_actor_info()
             subject_fullname = self.get_fullname_of(
                 activity.attrs['roles:userid'])
 
             return _(u'activity_participant_removed_body',
                      default=u'${actor} has removed the'
                      u' participant ${subject}.',
-                     mapping={'actor': actor_info.get('fullname'),
+                     mapping={'actor': actor_fullname,
                               'subject': subject_fullname})
 
         return None

--- a/ftw/participation/tests/test_activity.py
+++ b/ftw/participation/tests/test_activity.py
@@ -9,14 +9,15 @@ from ftw.testbrowser import browsing
 import transaction
 
 
-
 class TestActivity(FunctionalTestCase):
 
     @browsing
     def test_invitation_created_activity(self, browser):
         self.grant('Manager')
+        user = create(Builder('user').named(u'J\xf6hn', u'Doe')
+                      .with_roles('Manager'))
         folder = create(Builder('folder').providing(IParticipationSupport))
-        browser.login().open(folder, view='invite_participants')
+        browser.login(user).open(folder, view='invite_participants')
         browser.fill({'E-Mail Addresses': 'hugo@boss.com',
                       'Roles': ['Contributor'],
                       'Comment': u'Hi th\xf6re'})
@@ -30,9 +31,9 @@ class TestActivity(FunctionalTestCase):
                  'path': '/plone/folder'},
 
                 {'action': 'participation:invitation_created',
-                 'actor': 'test_user_1_',
+                 'actor': 'john.doe',
                  'path': '/plone/folder',
-                 'invitation:inviter': u'test_user_1_',
+                 'invitation:inviter': u'john.doe',
                  'invitation:email': u'hugo@boss.com',
                  'invitation:roles': (u'Contributor',),
                  'invitation:comment': u'Hi th\xf6re',
@@ -51,19 +52,19 @@ class TestActivity(FunctionalTestCase):
         newest_event = activity.events()[0]
         self.assertEquals(
             {'url': 'http://nohost/plone/folder',
-             'byline': 'Invitation created now by test_user_1_',
+             'byline': u'Invitation created now by Doe J\xf6hn',
              'title': ''},
             newest_event.infos())
         self.assertEquals(
-            'test_user_1_ has invited hugo@boss.com as Can add.',
+            u'Doe J\xf6hn has invited hugo@boss.com as Can add.',
             newest_event.body_text)
 
     @browsing
     def test_invitation_accepted_event(self, browser):
         self.grant('Manager')
         folder = create(Builder('folder').providing(IParticipationSupport))
-        inviter = create(Builder('user').named('John', 'Doe'))
-        user = create(Builder('user').named('Hugo', 'Boss'))
+        inviter = create(Builder('user').named(u'J\xf6hn', u'Doe'))
+        user = create(Builder('user').named(u'Hugo', u'B\xf6ss'))
         Invitation(target=folder,
                    email=user.getProperty('email'),
                    inviter=inviter.getId(),
@@ -100,7 +101,7 @@ class TestActivity(FunctionalTestCase):
         newest_event = activity.events()[0]
         self.assertEquals(
             {'url': 'http://nohost/plone/folder',
-             'byline': 'Invitation accepted now by Boss Hugo',
+             'byline': u'Invitation accepted now by B\xf6ss Hugo',
              'title': ''},
             newest_event.infos())
 
@@ -108,8 +109,8 @@ class TestActivity(FunctionalTestCase):
     def test_invitation_rejected_event(self, browser):
         self.grant('Manager')
         folder = create(Builder('folder').providing(IParticipationSupport))
-        inviter = create(Builder('user').named('John', 'Doe'))
-        user = create(Builder('user').named('Hugo', 'Boss'))
+        inviter = create(Builder('user').named(u'J\xf6hn', u'Doe'))
+        user = create(Builder('user').named(u'Hugo', u'B\xf6ss'))
         Invitation(target=folder,
                    email=user.getProperty('email'),
                    inviter=inviter.getId(),
@@ -146,7 +147,7 @@ class TestActivity(FunctionalTestCase):
         newest_event = activity.events()[0]
         self.assertEquals(
             {'url': 'http://nohost/plone/folder',
-             'byline': 'Invitation rejected now by Boss Hugo',
+             'byline': u'Invitation rejected now by B\xf6ss Hugo',
              'title': ''},
             newest_event.infos())
 
@@ -154,7 +155,7 @@ class TestActivity(FunctionalTestCase):
     def test_invitation_retracted_event(self, browser):
         self.grant('Manager')
         folder = create(Builder('folder').providing(IParticipationSupport))
-        inviter = create(Builder('user').named('John', 'Doe'))
+        inviter = create(Builder('user').named(u'J\xf6hn', u'Doe'))
         invitation = Invitation(target=folder,
                                 email='foo@bar.com',
                                 inviter=inviter.getId(),
@@ -192,11 +193,11 @@ class TestActivity(FunctionalTestCase):
         newest_event = activity.events()[0]
         self.assertEquals(
             {'url': 'http://nohost/plone/folder',
-             'byline': 'Invitation retracted now by Doe John',
+             'byline': u'Invitation retracted now by Doe J\xf6hn',
              'title': ''},
             newest_event.infos())
         self.assertEquals(
-            'Doe John has retracted the invitation for foo@bar.com.',
+            u'Doe J\xf6hn has retracted the invitation for foo@bar.com.',
             newest_event.body_text)
 
     @browsing
@@ -204,9 +205,9 @@ class TestActivity(FunctionalTestCase):
         self.grant('Manager')
         folder = create(Builder('folder').providing(IParticipationSupport))
 
-        hugo = create(Builder('user').named('Hugo', 'Boss')
+        hugo = create(Builder('user').named(u'Hugo', u'B\xf6ss')
                .with_roles('Manager', on=folder))
-        create(Builder('user').named('John', 'Doe')
+        create(Builder('user').named(u'J\xf6hn', u'Doe')
                .with_roles('Editor', on=folder))
 
         browser.login(hugo).open(folder, view='participants')
@@ -245,21 +246,21 @@ class TestActivity(FunctionalTestCase):
         newest_event = activity.events()[0]
         self.assertEquals(
             {'url': 'http://nohost/plone/folder',
-             'byline': 'Role changed now by Boss Hugo',
+             'byline': u'Role changed now by B\xf6ss Hugo',
              'title': ''},
             newest_event.infos())
         self.assertEquals(
-            'Boss Hugo has changed the role of Doe John'
-            ' from Can edit to Can add.',
+            u'B\xf6ss Hugo has changed the role of Doe J\xf6hn'
+            u' from Can edit to Can add.',
             newest_event.body_text)
 
     @browsing
     def test_local_role_removed(self, browser):
         self.grant('Manager')
         folder = create(Builder('folder').providing(IParticipationSupport))
-        hugo = create(Builder('user').named('Hugo', 'Boss')
+        hugo = create(Builder('user').named(u'Hugo', u'B\xf6ss')
                .with_roles('Manager', on=folder))
-        user = create(Builder('user').named('John', 'Doe')
+        user = create(Builder('user').named(u'J\xf6hn', u'Doe')
                       .with_roles('Editor', on=folder))
 
         browser.login(hugo).open(folder, view='participants')
@@ -289,9 +290,9 @@ class TestActivity(FunctionalTestCase):
         newest_event = activity.events()[0]
         self.assertEquals(
             {'url': 'http://nohost/plone/folder',
-             'byline': 'Participant removed now by Boss Hugo',
+             'byline': u'Participant removed now by B\xf6ss Hugo',
              'title': ''},
             newest_event.infos())
         self.assertEquals(
-            'Boss Hugo has removed the participant Doe John.',
+            u'B\xf6ss Hugo has removed the participant Doe J\xf6hn.',
             newest_event.body_text)


### PR DESCRIPTION
When a user has umlauts in the name, an unicode decoding error did occur while rendering participation events in an activity stream.