### PR TITLE
Improve ftw.lawgiver support for translated role titles.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.4.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Improve ftw.lawgiver support for translated role titles. [jone]
 
 
 1.4.1 (2016-12-09)

--- a/ftw/participation/activity/renderer.py
+++ b/ftw/participation/activity/renderer.py
@@ -18,9 +18,9 @@ class InvitationRenderer(DefaultRenderer):
     def render(self, activity, obj):
         return self.index(activity=activity,
                           obj=obj,
-                          comment=self.prepare_comment(activity))
+                          comment=self.prepare_comment(activity, obj))
 
-    def prepare_comment(self, activity):
+    def prepare_comment(self, activity, obj):
         action = activity.attrs['action']
         actor_info = activity.get_actor_info()
         actor_fullname = actor_info.get('fullname').decode('utf-8')
@@ -28,7 +28,7 @@ class InvitationRenderer(DefaultRenderer):
         if action == 'participation:invitation_created':
             actor_email = activity.attrs['invitation:email'].decode('utf-8')
             roles = translate_and_join_roles(
-                activity.attrs['invitation:roles'], self.request)
+                activity.attrs['invitation:roles'], obj, self.request)
 
             return _(u'activity_invitation_created_body',
                      default=u'${inviter} has invited ${mail} as ${roles}.',
@@ -39,7 +39,7 @@ class InvitationRenderer(DefaultRenderer):
         if action == 'participation:invitation_retracted':
             actor_email = activity.attrs['invitation:email'].decode('utf-8')
             roles = translate_and_join_roles(
-                activity.attrs['invitation:roles'], self.request)
+                activity.attrs['invitation:roles'], obj, self.request)
 
             return _(u'activity_invitation_retracted_body',
                      default=u'${actor} has retracted the invitation'
@@ -51,9 +51,9 @@ class InvitationRenderer(DefaultRenderer):
             subject_fullname = self.get_fullname_of(
                 activity.attrs['roles:userid'])
             removed_roles = translate_and_join_roles(
-                activity.attrs['roles:removed'], self.request)
+                activity.attrs['roles:removed'], obj, self.request)
             added_roles = translate_and_join_roles(
-                activity.attrs['roles:added'], self.request)
+                activity.attrs['roles:added'], obj, self.request)
 
             return _(u'activity_role_changed_body',
                      default=u'${actor} has changed the role of ${subject}'

--- a/ftw/participation/activity/utils.py
+++ b/ftw/participation/activity/utils.py
@@ -3,7 +3,7 @@ from ftw.participation.browser.participants import get_friendly_role_names
 from zope.i18n import translate
 
 
-def translate_and_join_roles(roles, request):
-    roles = get_friendly_role_names(roles, request)
+def translate_and_join_roles(roles, context, request):
+    roles = get_friendly_role_names(roles, context, request)
     and_ = translate(_(' and '), context=request)
     return ', '.join(roles[:-2] + [and_.join(roles[-2:])])

--- a/ftw/participation/tests/test_activity_utils.py
+++ b/ftw/participation/tests/test_activity_utils.py
@@ -7,20 +7,20 @@ class TestInvitationRenderer(FunctionalTestCase):
     def test_translate_and_join_roles__1_role(self):
         self.assertEquals(
             'Can add',
-            translate_and_join_roles(('Contributor',), None))
+            translate_and_join_roles(('Contributor',), None, None))
 
     def test_translate_and_join_roles__2_roles(self):
         self.assertEquals(
             'Can add and Can view',
-            translate_and_join_roles(('Reader', 'Contributor'), None))
+            translate_and_join_roles(('Reader', 'Contributor'), None, None))
 
     def test_translate_and_join_roles__3_roles(self):
         self.assertEquals(
             'Can add, Can edit and Can view',
-            translate_and_join_roles(('Reader', 'Editor', 'Contributor'), None))
+            translate_and_join_roles(('Reader', 'Editor', 'Contributor'), None, None))
 
     def test_translate_and_join_roles__4_roles(self):
         self.assertEquals(
             'Can add, Can edit and Can view',
             translate_and_join_roles(
-                ('Reader', 'Editor', 'Contributor', 'Manager'), None))
+                ('Reader', 'Editor', 'Contributor', 'Manager'), None, None))


### PR DESCRIPTION
The standard way to get the role title for translation is to use an `ISharingPageRole` utility, which has the _global_ title of this role.

`ftw.lawgiver` introduces a concept of workflow specific titles / translations for roles, which are hooked into the `ISharingPageRole` utility by looking up the traversed context from the request.

This concept does not work though when rendering roles for multiple context: in this case for a list of activities, which may have contexts with different workflows and thus different role titles.

In order to address this, we now directly lookup the role title from the the context bound `IDynamicRoleAdapter` (introduced by `ftw.lawgiver`), so that we do not depend on the traversed context from the request.

@maethu can you take a look at this one?