### PR TITLE
Restore compatibility with newest ftw.testbrowser.

### DIFF
--- a/ftw/participation/tests/test_browser_participants.py
+++ b/ftw/participation/tests/test_browser_participants.py
@@ -10,7 +10,6 @@ from ftw.testing.mailing import Mailing
 from plone.app.testing import login
 from plone.registry.interfaces import IRegistry
 from unittest2 import TestCase
-from zExceptions import Forbidden
 from zope.component import getUtility
 import transaction
 
@@ -209,7 +208,7 @@ class TestParticipantsView(TestCase):
         browser.fill({'userids:list': [jane.getId()]})
         browser.login(hugo.getId())
 
-        with self.assertRaises(Forbidden):
+        with browser.expect_http_error(reason='Forbidden'):
             browser.find('Delete Participants').click()
 
     @browsing

--- a/ftw/participation/tests/test_change_roles.py
+++ b/ftw/participation/tests/test_change_roles.py
@@ -4,7 +4,6 @@ from ftw.participation.interfaces import IParticipationSupport
 from ftw.participation.tests.layer import FTW_PARTICIPATION_FUNCTIONAL_TESTING
 from ftw.testbrowser import browsing
 from unittest2 import TestCase
-from zExceptions import BadRequest
 import transaction
 
 
@@ -98,12 +97,12 @@ class TestChangeRoles(TestCase):
 
     @browsing
     def test_raise_bad_request_if_no_memberid_is_given(self, browser):
-        with self.assertRaises(BadRequest):
+        with browser.expect_http_error(reason='Bad Request'):
             browser.login().visit(self.folder, view='change_roles')
 
     @browsing
     def test_raise_bad_request_if_no_valid_memberid_is_given(self, browser):
-        with self.assertRaises(BadRequest):
+        with browser.expect_http_error(reason='Bad Request'):
             data = {'form.widgets.memberid': 'invalid_member_id'}
             browser.login().visit(self.folder, view='change_roles', data=data)
 

--- a/ftw/participation/tests/test_invite.py
+++ b/ftw/participation/tests/test_invite.py
@@ -12,7 +12,6 @@ from plone import api
 from plone.app.layout.navigation.interfaces import INavigationRoot
 from plone.registry.interfaces import IRegistry
 from unittest2 import TestCase
-from zExceptions import NotFound
 from zope.component import getUtility
 from zope.interface import alsoProvides
 import transaction
@@ -177,7 +176,7 @@ class TestInviteForm(TestCase):
         config.allow_invite_email = False
         transaction.commit()
 
-        with self.assertRaises(NotFound):
+        with browser.expect_http_error(reason='Not Found'):
             browser.login().visit(self.folder, view='invite_participants')
 
     @browsing


### PR DESCRIPTION
The error handling has changed in the newest ftw.testbrowser version.