### PR TITLE
Add version pinning for node.

### DIFF
--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -7,3 +7,6 @@ package-name = ftw.participation
 
 versions=versions
 
+[versions]
+# node version 1.0 is only compatible with plone 5
+node = <1.0


### PR DESCRIPTION
Node version 1.0 only works with plone 5.
Nightlies have been failing for some time.